### PR TITLE
Add door configs for Toliss A21N.

### DIFF
--- a/BetterPushback_doors.cfg
+++ b/BetterPushback_doors.cfg
@@ -211,6 +211,28 @@ door AirbusFBW/GroundHPAir
 door AirbusFBW/GroundLPAir
 door AirbusFBW/EnableExternalPower
 
+# X-Plane 12 Toliss A321Neo Hi Definition
+icao	A21N
+studio	ToLiss
+acf a321.acf
+door @AirbusFBW/PaxDoorArray
+door @AirbusFBW/CargoDoorArray
+door AirbusFBW/BulkDoor
+door AirbusFBW/GroundHPAir
+door AirbusFBW/GroundLPAir
+door AirbusFBW/EnableExternalPower
+
+# X-Plane 12 Toliss A321Neo Std Definition
+icao	A21N
+studio	ToLiss
+acf a321_StdDef.acf
+door @AirbusFBW/PaxDoorArray
+door @AirbusFBW/CargoDoorArray
+door AirbusFBW/BulkDoor
+door AirbusFBW/GroundHPAir
+door AirbusFBW/GroundLPAir
+door AirbusFBW/EnableExternalPower
+
 #################################################
 #		       tolis xplane 11 		     		#
 #################################################
@@ -270,6 +292,28 @@ door AirbusFBW/EnableExternalPower
 
 # X-Plane 11 Toliss A321 Std Definition
 icao	A321
+studio	ToLiss
+acf a321_XP11_StdDef.acf
+door @AirbusFBW/PaxDoorArray
+door @AirbusFBW/CargoDoorArray
+door AirbusFBW/BulkDoor
+door AirbusFBW/GroundHPAir
+door AirbusFBW/GroundLPAir
+door AirbusFBW/EnableExternalPower
+
+# X-Plane 12 Toliss A321Neo Hi Definition
+icao	A21N
+studio	ToLiss
+acf a321_XP11.acf
+door @AirbusFBW/PaxDoorArray
+door @AirbusFBW/CargoDoorArray
+door AirbusFBW/BulkDoor
+door AirbusFBW/GroundHPAir
+door AirbusFBW/GroundLPAir
+door AirbusFBW/EnableExternalPower
+
+# X-Plane 12 Toliss A321Neo Std Definition
+icao	A21N
 studio	ToLiss
 acf a321_XP11_StdDef.acf
 door @AirbusFBW/PaxDoorArray


### PR DESCRIPTION
When the player switches to the Neo Add-on, the ICAO  dataref for the loaded aircraft is A21N instead of A321. If this configuration is not anticipated, the pushback vehicle will start pushback even though all doors are still open.