### PR TITLE
Add Q4XP door checks

### DIFF
--- a/BetterPushback_doors.cfg
+++ b/BetterPushback_doors.cfg
@@ -301,7 +301,7 @@ door AirbusFBW/GroundHPAir
 door AirbusFBW/GroundLPAir
 door AirbusFBW/EnableExternalPower
 
-# X-Plane 12 Toliss A321Neo Hi Definition
+# X-Plane 11 Toliss A321Neo Hi Definition
 icao	A21N
 studio	ToLiss
 acf a321_XP11.acf
@@ -312,7 +312,7 @@ door AirbusFBW/GroundHPAir
 door AirbusFBW/GroundLPAir
 door AirbusFBW/EnableExternalPower
 
-# X-Plane 12 Toliss A321Neo Std Definition
+# X-Plane 11 Toliss A321Neo Std Definition
 icao	A21N
 studio	ToLiss
 acf a321_XP11_StdDef.acf
@@ -571,3 +571,13 @@ icao	B77L
 studio	FlightFactor
 acf	777-F_xp12.acf
 door anim/LFmov/door
+
+# FlyJSim Q4XP for X-Plane 11 & 12
+icao	DH8D
+author	FlyJSim
+acf	Q4XP.acf
+door @FJS/Q4XP/Manips/CabinDoors_Ctl
+door @FJS/Q4XP/Manips/CabinMainDoor_Ctl
+door @FJS/Q4XP/Manips/CargoDoor_Ctl
+door FJS/Q4XP/Ext/show_fuel_cart
+door FJS/Q4XP/Ext/show_gpu

--- a/src/bp.c
+++ b/src/bp.c
@@ -511,9 +511,9 @@ doors_refs_init(void)
 		if (fp == NULL) {
 			return;
 		}
-		logMsg("founded : BetterPushback_doors.cfg in plugins folder");	
+		logMsg("found : BetterPushback_doors.cfg in plugins folder");	
 	} else {
-	logMsg("founded : BetterPushback_doors.cfg in Output/preferences folder");
+	logMsg("found : BetterPushback_doors.cfg in Output/preferences folder");
 	}
 
 #define	FILTER_PARAM(param) \


### PR DESCRIPTION
Main change
- Added door config for FlyJSim Q4XP
- Corrected comment for A21N XP11 section
- Corrected grammar in bp.c log from "founded" to "found"