### PR TITLE
feat: Mute the GPU and doors message based on setting

### DIFF
--- a/data/po/de/strings.po
+++ b/data/po/de/strings.po
@@ -260,6 +260,11 @@ msgid "The tug appears next to the plane avoiding in certain case that he is "
     "travelling inside the buildings."
 msgstr  "Das Schleppfahrzeug erscheint neben dem Flugzeug und vermeidet in bestimmten Fällen, dass es durch Gebäude fährt."
 
+msgid   "Mutes the message that the GPU is still connected or "
+        "some doors are still open."
+msgstr  "Stummschaltet die Nachricht, dass die GPU noch verbunden ist oder "
+        "einige Türen noch offen sind."
+
 msgid "The tug will appear once the beacon light is switched from off to on "
       "then the process will proceed as 'connect the tug first'."
 msgstr  "Der Schlepper erscheint, sobald das Beacon-Licht von aus auf an geschaltet wird, "
@@ -267,6 +272,9 @@ msgstr  "Der Schlepper erscheint, sobald das Beacon-Licht von aus auf an geschal
         
 msgid "Tug starts near the aircraft"
 msgstr  "Das Schleppfahrzeug startet in der Nähe des Flugzeugs"
+
+msgid "Mute GPU and doors message"
+msgstr  "GPU- und Türmeldungen stummschalten"
 
 msgid "Tug called by activating the beacon"
 msgstr  "Das Schleppfahrzeug wird durch Aktivierung des Beacon-Lichts gerufen"

--- a/data/po/es/strings.po
+++ b/data/po/es/strings.po
@@ -259,6 +259,11 @@ msgid "The tug appears next to the plane avoiding in certain case that he is "
     "travelling inside the buildings."
 msgstr  "El remolcador aparece junto al avión, evitando en ciertos casos que pase por dentro de los edificios."
 
+msgid   "Mutes the message that the GPU is still connected or "
+        "some doors are still open."
+msgstr  "Silencia el mensaje de que la GPU aún está conectada o "
+        "algunas puertas aún están abiertas."
+
 msgid "The tug will appear once the beacon light is switched from off to on "
       "then the process will proceed as 'connect the tug first'."
 msgstr  "El remolcador aparecerá una vez que la luz del faro pase de apagada a encendida, "
@@ -266,6 +271,9 @@ msgstr  "El remolcador aparecerá una vez que la luz del faro pase de apagada a 
 
 msgid "Tug starts near the aircraft"
 msgstr  "El remolcador comienza cerca del avión"
+
+msgid "Mute GPU and doors message
+msgstr  "Silenciar mensaje de GPU y puertas"
 
 msgid "Tug called by activating the beacon"
 msgstr  "El remolcador se activa encendiendo el faro"

--- a/data/po/fr/strings.po
+++ b/data/po/fr/strings.po
@@ -430,6 +430,11 @@ msgid "The tug appears next to the plane avoiding in certain case that he is "
     "travelling inside the buildings."
 msgstr  "Le tracteur apparaît à côté de l'avion, évitant dans certains cas que celui passe à travers les bâtiments."
 
+msgid   "Mutes the message that the GPU is still connected or "
+        "some doors are still open."
+msgstr  "Silence le message que le GPU est toujours connecté ou "
+        "que certaines portes sont encore ouvertes."
+
 msgid "The tug will appear once the beacon light is switched from off to on "
       "then the process will proceed as 'connect the tug first'."
 msgstr  "Le tracteur apparaîtra une fois que l'anti-collision sera allumée, "
@@ -437,6 +442,9 @@ msgstr  "Le tracteur apparaîtra une fois que l'anti-collision sera allumée, "
 
 msgid "Tug starts near the aircraft"
 msgstr  "Le tracteur démarre près de l'avion"
+
+msgid "Mute GPU and doors message"
+msgstr  "Silence GPU et message des portes"
 
 msgid "Tug called by activating the beacon"
 msgstr  "Le tracteur est appelé en activant l'anti-collision"

--- a/data/po/it/strings.po
+++ b/data/po/it/strings.po
@@ -279,6 +279,11 @@ msgid "The tug appears next to the plane avoiding in certain case that he is "
     "travelling inside the buildings."
 msgstr  "Il trattore appare accanto all'aereo, evitando in alcuni casi di attraversare gli edifici."
 
+msgid   "Mutes the message that the GPU is still connected or "
+        "some doors are still open."
+msgstr  "Silenzia il messaggio che la GPU è ancora connessa o "
+        "alcune porte sono ancora aperte."
+
 msgid "The tug will appear once the beacon light is switched from off to on "
       "then the process will proceed as 'connect the tug first'."
 msgstr  "Il trattore apparirà una volta che la luce del faro sarà accesa, "
@@ -287,6 +292,9 @@ msgstr  "Il trattore apparirà una volta che la luce del faro sarà accesa, "
 
 msgid "Tug starts near the aircraft"
 msgstr  "Il trattore inizia vicino all'aereo"
+
+msgid "Mute GPU and doors message"
+msgstr  "Silenzia il messaggio GPU e porte"
 
 msgid "Tug called by activating the beacon"
 msgstr  "Il trattore viene chiamato attivando il faro"

--- a/data/po/pt/strings.po
+++ b/data/po/pt/strings.po
@@ -260,6 +260,11 @@ msgid "The tug appears next to the plane avoiding in certain case that he is "
     "travelling inside the buildings."
 msgstr  "O reboque aparece ao lado do avião, evitando em certos casos que ele passe por dentro dos edifícios."
 
+msgid   "Mutes the message that the GPU is still connected or "
+        "some doors are still open."
+msgstr  "Silencia a mensagem de que a GPU ainda está conectada ou "
+        "algumas portas ainda estão abertas."
+
 msgid "The tug will appear once the beacon light is switched from off to on "
       "then the process will proceed as 'connect the tug first'."
 msgstr  "O reboque aparecerá assim que a luz do farol for ligada, "
@@ -267,6 +272,9 @@ msgstr  "O reboque aparecerá assim que a luz do farol for ligada, "
 
 msgid "Tug starts near the aircraft"
 msgstr  "O reboque começa próximo à aeronave"
+
+msgid "Mute GPU and doors message"
+msgstr  "Silenciar mensagem de GPU e portas"
 
 msgid "Tug called by activating the beacon"
 msgstr  "O reboque é chamado ao ativar o beacon"

--- a/data/po/pt_BR/strings.po
+++ b/data/po/pt_BR/strings.po
@@ -575,6 +575,11 @@ msgid "The tug appears next to the plane avoiding in certain case that he is "
     "travelling inside the buildings."
 msgstr  "O reboque aparece ao lado do avião, evitando em alguns casos que ele passe por dentro dos prédios."
 
+msgid   "Mutes the message that the GPU is still connected or "
+        "some doors are still open."
+msgstr  "Silencia a mensagem de que a GPU ainda está conectada ou "
+        "algumas portas ainda estão abertas."
+
 msgid "The tug will appear once the beacon light is switched from off to on "
       "then the process will proceed as 'connect the tug first'."
 msgstr  "O reboque aparecerá assim que a luz do beacon for ligada, "
@@ -582,6 +587,9 @@ msgstr  "O reboque aparecerá assim que a luz do beacon for ligada, "
 
 msgid "Tug starts near the aircraft"
 msgstr  "O reboque começa próximo à aeronave"
+
+msgid "Mute GPU and doors message"
+msgstr  "Silenciar mensagem de GPU e portas"
 
 msgid "Tug called by activating the beacon"
 msgstr  "O reboque é acionado ao ativar o beacon"

--- a/data/po/ru/strings.po
+++ b/data/po/ru/strings.po
@@ -263,6 +263,11 @@ msgid "The tug appears next to the plane avoiding in certain case that he is "
     "travelling inside the buildings."
 msgstr  "Трактор появляется рядом с самолетом, избегая в некоторых случаях проезда через здания."
 
+msgid   "Mutes the message that the GPU is still connected or "
+        "some doors are still open."
+msgstr  "Заглушает сообщение о том, что GPU все еще подключен или "
+        "некоторые двери все еще открыты."
+
 msgid "The tug will appear once the beacon light is switched from off to on "
       "then the process will proceed as 'connect the tug first'."
 msgstr  "Трактор появится, как только свет маяка переключится с выключенного на включенный, "
@@ -270,6 +275,9 @@ msgstr  "Трактор появится, как только свет маяк�
 
 msgid "Tug starts near the aircraft"
 msgstr  "Трактор начинает движение рядом с самолетом"
+
+msgid "Mute GPU and doors message"
+msgstr  "Заглушить сообщение GPU и дверей"
 
 msgid "Tug called by activating the beacon"
 msgstr  "Трактор вызывается активацией маяка"

--- a/data/po/strings.pot
+++ b/data/po/strings.pot
@@ -446,11 +446,18 @@ msgid   "The tug appears next to the plane avoiding in certain case that he "
         "is travelling inside the buildings."
 msgstr  ""
 
+msgid   "Mutes the message that the GPU is still connected or "
+        "some doors are still open."
+msgstr  ""
+
 msgid   "The tug will appear once the beacon light is switched from off to on "
         "then the process will proceed as 'connect the tug first'."
 msgstr  ""
 
 msgid   "Tug starts near the aircraft"
+msgstr  ""
+
+msgid   "Mute GPU and doors message"
 msgstr  ""
 
 msgid   "Tug called by activating the beacon"

--- a/data/po/zh-bck/strings.po
+++ b/data/po/zh-bck/strings.po
@@ -170,6 +170,10 @@ msgid "The tug appears next to the plane avoiding in certain case that he is "
     "travelling inside the buildings."
 msgstr  "拖车出现在飞机旁，避免在某些情况下穿过建筑物内部。"
 
+msgid   "Mutes the message that the GPU is still connected or "
+        "some doors are still open."
+msgstr  "静音GPU和门消息"
+
 msgid "The tug will appear once the beacon light is switched from off to on "
       "then the process will proceed as 'connect the tug first'."
 msgstr  "拖车将在信标灯从关闭切换到开启时出现，"
@@ -177,6 +181,9 @@ msgstr  "拖车将在信标灯从关闭切换到开启时出现，"
 
 msgid "Tug starts near the aircraft"
 msgstr  "拖车从飞机附近开始"
+
+msgid "Mute GPU and doors message"
+msgstr  "静音GPU和门消息"
 
 msgid "Tug called by activating the beacon"
 msgstr  "通过激活信标呼叫拖车"

--- a/data/po/zh/strings.po
+++ b/data/po/zh/strings.po
@@ -273,6 +273,10 @@ msgid "The tug appears next to the plane avoiding in certain case that he is "
     "travelling inside the buildings."
 msgstr  "拖车出现在飞机旁，避免在某些情况下穿过建筑物内部。"
 
+msgid   "Mutes the message that the GPU is still connected or "
+        "some doors are still open."
+msgstr  "静音GPU和门消息"
+
 msgid "The tug will appear once the beacon light is switched from off to on "
       "then the process will proceed as 'connect the tug first'."
 msgstr  "拖车将在信标灯从关闭切换到开启时出现，"
@@ -280,6 +284,9 @@ msgstr  "拖车将在信标灯从关闭切换到开启时出现，"
 
 msgid "Tug starts near the aircraft"
 msgstr  "拖车从飞机附近开始"
+
+msgid "Mute GPU and doors message"
+msgstr  "静音GPU和门消息"
 
 msgid "Tug called by activating the beacon"
 msgstr  "通过激活信标呼叫拖车"

--- a/src/bp.c
+++ b/src/bp.c
@@ -2377,7 +2377,12 @@ pb_step_connected(void) {
 static void
 pb_step_waiting_for_doors(void) {
     if (!acf_doors_closed(B_TRUE)) {
-        XPLMSpeakString(_(MSG_DOORS_GPU));
+        bool_t mute_when_gpu_still_connected = B_FALSE;
+        (void) conf_get_b(bp_conf,"mute_when_gpu_still_connected", &mute_when_gpu_still_connected);
+
+        if (!mute_when_gpu_still_connected) {
+            XPLMSpeakString(_(MSG_DOORS_GPU));
+        }
     } 
     bp.step++;
     bp.step_start_t = bp.cur_t;

--- a/src/cfg.cpp
+++ b/src/cfg.cpp
@@ -135,6 +135,9 @@ const char *always_connect_tug_first_tooltip =
 const char *tug_starts_next_plane_tooltip =
     "The tug appears next to the plane avoiding in certain case that he is "
     "travelling inside the buildings.";
+const char *mute_when_gpu_still_connected_tooltip =
+    "Mutes the message that the GPU is still connected or "
+    "some doors are still open.";
 const char *tug_auto_start_tooltip =
     "The tug will appear once the beacon light is switched from off to on "
     "then the process will proceed as 'connect the tug first'.";
@@ -256,6 +259,7 @@ private:
   bool_t per_aircraft_is_global;
   bool_t xp11_only;
   bool_t is_destroy;
+  bool_t mute_when_gpu_still_connected;
   bool_t tug_starts_next_plane;
   bool_t tug_auto_start;
   int monitor_id;
@@ -336,6 +340,9 @@ void SettingsWindow::LoadConfig(void) {
 
   tug_starts_next_plane = B_FALSE;
   (void)conf_get_b(bp_conf, "tug_starts_next_plane", &tug_starts_next_plane);
+
+  mute_when_gpu_still_connected = B_FALSE;
+  (void)conf_get_b(bp_conf, "mute_when_gpu_still_connected", &mute_when_gpu_still_connected);
 
 // feature disabled for now
 //  tug_auto_start = B_FALSE;
@@ -716,6 +723,17 @@ void SettingsWindow::buildInterface() {
     if (ImGui::Checkbox("##tug_starts_next_plane",
                         (bool *)&tug_starts_next_plane)) {
       (void)conf_set_b(bp_conf, "tug_starts_next_plane", tug_starts_next_plane);
+    }
+
+    ImGui::TableNextRow();
+    ImGui::TableNextColumn();
+    ImGui::Text("%s", _("Mute GPU and doors message"));
+    Tooltip(_(mute_when_gpu_still_connected_tooltip));
+
+    ImGui::TableNextColumn();
+    if (ImGui::Checkbox("##mute_when_gpu_still_connected",
+                        (bool *)&mute_when_gpu_still_connected)) {
+      (void)conf_set_b(bp_conf, "mute_when_gpu_still_connected", mute_when_gpu_still_connected);
     }
 
 /*


### PR DESCRIPTION
## Feature
A new setting that enables the user to toggle the XPLMSpeakString message on/off: "Some doors are still open or the GPU or the ASU is still connected."

## Background
Asking for the pushback truck was always a delicate balance between starting the APU on time and requesting the truck. If the APU starts on time, and ground power is disconnected, the truck proceeds perfectly. When the pushback truck arrives before the GPU has disconnected though, the pushback driver gets impatient and runs the XPLMSpeakString message, killing immersion.

I wanted the plugin to offer an option to disable that message so the driver waits patiently until the GPU is disconnected and all doors are closed.

<img width="884" height="828" alt="gpu_doors" src="https://github.com/user-attachments/assets/654de2cd-cea1-4855-9b42-66557143505e" />
