### PR TITLE
fix: Add infinite replanning when the tug is connected

### DIFF
--- a/src/xplane.c
+++ b/src/xplane.c
@@ -326,11 +326,17 @@ start_pb_handler_(XPLMCommandRef cmd, XPLMCommandPhase phase, void *refcon)
 
     if (!start_pb_enable)
     {
-        logMsg(BP_WARN_LOG "Command \"BetterPushback/start\" is currently disabled");
-        if (push_manual.requested) {
-            manual_bp_stop();
+        if (bp.step == PB_STEP_CONNECTED) {
+            start_pb_enable = B_TRUE;
+            late_plan_requested = B_TRUE;
         }
-        return (1);
+        else {
+            logMsg(BP_WARN_LOG "Command \"BetterPushback/start\" is currently disabled");
+            if (push_manual.requested) {
+                manual_bp_stop();
+            }
+            return (1);
+        }
     }
 
     if (push_manual.requested) {


### PR DESCRIPTION
## Feature

This feature is most helpful for the "Connect tug first" users. This adds a change to the `PB_STEP_CONNECTED` state, the state where the tug driver is connected but waiting for the parking brake to be released. When in that state, the pilot could "start" the pushback, and the plugin would ask for a plan. The plugin calls this `late_plan_requested`. This could only be done once, though. After one `late_plan_requested` has been chosen, the user could never change that plan anymore.

This PR changes that, and lets the pilot plan numerous changes. After the parking brake is released once though, the plan is locked, just like before.

### Background
When flying online with Vatsim in busy areas, it's not uncommon to get different pushback clearances as the controller changes heart. I've had this happen a few times now, and had to disconnect the tug, reconnect and plan again. A timely process. That is why I created this PR.