### PR TITLE
fix: Fix for stuck pushback when late_plan_requested

### DIFF
--- a/src/bp.c
+++ b/src/bp.c
@@ -2309,6 +2309,7 @@ pb_step_lift(void) {
              */
             if (!late_plan_end_cond()) {
                 bp_hint_status_str = _("Connected to the aircraft, waiting for clearance");
+                enable_replanning();
                 return;
             }
             late_plan_requested = B_FALSE;


### PR DESCRIPTION
See https://github.com/olivierbutler/BetterPusbackMod/pull/21.

Fix for issue where users that selected "Connect tug first" could not continue the planning process since the menu item was disabled.