### PR TITLE
Functional Enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.zip
 *.cbp
 .idea
+.DS_Store
 lin64
 win64
 mac64

--- a/README.md
+++ b/README.md
@@ -70,6 +70,30 @@ For details on how to add tug liveries, see
 
 To add a voice set, see `data/msgs/README.txt` for the information.
 
+## Commands
+
+BetterPushback registers these X-Plane commands:
+
+- `BetterPushback/start`: Start pushback (or connect-first if configured).
+- `BetterPushback/stop`: Stop pushback.
+- `BetterPushback/start_planner`: Open the pushback planner.
+- `BetterPushback/stop_planner`: Close the pushback planner.
+- `BetterPushback/connect_first`: Connect the tug before planning/pushback.
+- `BetterPushback/cab_camera`: View from the tug cab.
+- `BetterPushback/recreate_scenery_routes`: Recreate scenery routes from WED files.
+- `BetterPushback/preference`: Open the preference window.
+- `BetterPushback/reload`: Reload BetterPushback (disabled if pushback is running,
+  the planner is open, or the preferences window is active).
+- `BetterPushback/abort_push`: Abort pushback during coupled push.
+- `BetterPushback/manual_push_left`: Turn the tug left (manual push).
+- `BetterPushback/manual_push_right`: Turn the tug right (manual push).
+- `BetterPushback/manual_push_toggle`: Toggle manual push direction.
+- `BetterPushback/manual_push_start`: Start/pause manual push (yoke used).
+- `BetterPushback/manual_push_start_no_yoke`: Start/pause manual push (no yoke).
+
+Note: For coupling add-ons, only `BetterPushback/start` is intended to be
+mirrored to the slave. Other commands remain local.
+
 ### libacfutils Library Required
 
 I removed from the project. It need to by downloaded separatly. To make sure you have a matched version, take the fork in my repository.

--- a/build_xpl.sh
+++ b/build_xpl.sh
@@ -81,7 +81,8 @@ set -e
 # for one make instance to be blocking on disk.
 HOST_OS="$(uname)"
 if [[ "$HOST_OS" = "Darwin" ]]; then
-	NCPUS=$(( $(sysctl -n hw.ncpu) + 1 ))
+	NCPU_COUNT=$(sysctl -n hw.ncpu 2>/dev/null || echo 1)
+	NCPUS=$(( NCPU_COUNT + 1 ))
 else
 	NCPUS=$(( $(grep 'processor[[:space:]]\+:' /proc/cpuinfo  | wc -l) + \
 	    1 ))

--- a/data/po/strings.pot
+++ b/data/po/strings.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: PACKAGE VERSION\n"
         "Report-Msgid-Bugs-To: \n"
-        "POT-Creation-Date: 2025-10-07 10:25+0300\n"
+        "POT-Creation-Date: 2025-11-13 18:20+0100\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -76,26 +76,26 @@ msgid   "Pushback failure: please first plan your pushback to tell me where "
         "you want to go."
 msgstr  ""
 
-#: src/bp.c:2004 src/bp.c:2018
+#: src/bp.c:2004 src/bp.c:2018 src/bp.c:2020
 #, c-format
 msgid   "ERROR: master requested tug \"%s\", which we don't have in our in "
         "our library. Please sync your tug libraries before trying again."
 msgstr  ""
 
-#: src/bp.c:2123 src/bp.c:2137
+#: src/bp.c:2123 src/bp.c:2137 src/bp.c:2139
 msgid   "Pushback warning: unable to remove your chocks. Remove them "
         "yourself, or else I won't be able to push your aircraft."
 msgstr  ""
 
-#: src/bp.c:2394 src/bp.c:2398 src/bp.c:2415
+#: src/bp.c:2394 src/bp.c:2398 src/bp.c:2415 src/bp.c:2417
 msgid   "Hey! Quit blinding me with your landing lights! Turn them off!"
 msgstr  ""
 
-#: src/bp.c:2397 src/bp.c:2401 src/bp.c:2418
+#: src/bp.c:2397 src/bp.c:2401 src/bp.c:2418 src/bp.c:2420
 msgid   "Hey! Quit blinding me with your taxi light! Turn it off!"
 msgstr  ""
 
-#: src/bp.c:3338 src/bp.c:3342 src/bp.c:3359
+#: src/bp.c:3338 src/bp.c:3342 src/bp.c:3359 src/bp.c:3361
 msgid   "Pushback failure: your flight controls are preventing me from "
         "steering the aircraft. Unbind any buttons you have set to \"toggle "
         "nosewheel steering\"."
@@ -203,73 +203,74 @@ msgstr  ""
 msgid   "Settings related to the current aircraft"
 msgstr  ""
 
-#: src/xplane.c:646
+#: src/xplane.c:646 src/xplane.c:648
 msgid   "ERROR: Unable to select pushback tug view at this time."
 msgstr  ""
 
-#: src/xplane.c:822 src/xplane.c:854
+#: src/xplane.c:822 src/xplane.c:854 src/xplane.c:824 src/xplane.c:856
 msgid   "Pushback failure: smartcopilot attempted to switch master/slave or "
         "network connection lost. Stopping operation."
 msgstr  ""
 
-#: src/xplane.c:840 src/xplane.c:868
+#: src/xplane.c:840 src/xplane.c:868 src/xplane.c:842 src/xplane.c:870
 msgid   "Pushback failure: Shared Flight attempted to switch pilot flying or "
         "network connection lost. Stopping operation."
 msgstr  ""
 
-#: src/xplane.c:963 src/xplane.c:1162 src/xplane.c:1394
+#: src/xplane.c:963 src/xplane.c:1162 src/xplane.c:1394 src/xplane.c:965
+#: src/xplane.c:1168 src/xplane.c:1400
 msgid   "Start pushback"
 msgstr  ""
 
-#: src/xplane.c:1381
+#: src/xplane.c:1381 src/xplane.c:1387
 msgid   "Change pushback"
 msgstr  ""
 
-#: src/xplane.c:965 src/xplane.c:1164
+#: src/xplane.c:965 src/xplane.c:1164 src/xplane.c:967 src/xplane.c:1170
 msgid   "Stop pushback"
 msgstr  ""
 
-#: src/xplane.c:967
+#: src/xplane.c:967 src/xplane.c:969
 msgid   "Start pushback planner"
 msgstr  ""
 
-#: src/xplane.c:969
+#: src/xplane.c:969 src/xplane.c:971
 msgid   "Stop pushback planner"
 msgstr  ""
 
-#: src/xplane.c:971
+#: src/xplane.c:971 src/xplane.c:973
 msgid   "Connect tug before entering pushback plan"
 msgstr  ""
 
-#: src/xplane.c:973
+#: src/xplane.c:973 src/xplane.c:975
 msgid   "View from tug's cab."
 msgstr  ""
 
-#: src/xplane.c:976
+#: src/xplane.c:976 src/xplane.c:978
 msgid   "Recreate scenery routes from WED files."
 msgstr  ""
 
-#: src/xplane.c:982
+#: src/xplane.c:982 src/xplane.c:984
 msgid   "Abort pushback during coupled push"
 msgstr  ""
 
-#: src/xplane.c:1156
+#: src/xplane.c:1156 src/xplane.c:1162
 msgid   "Pre-plan pushback"
 msgstr  ""
 
-#: src/xplane.c:1158
+#: src/xplane.c:1158 src/xplane.c:1164
 msgid   "Close pushback planner"
 msgstr  ""
 
-#: src/xplane.c:1160
+#: src/xplane.c:1160 src/xplane.c:1166
 msgid   "Connect tug first"
 msgstr  ""
 
-#: src/xplane.c:1170
+#: src/xplane.c:1170 src/xplane.c:1176
 msgid   "Preferences..."
 msgstr  ""
 
-#: src/xplane.c:1166
+#: src/xplane.c:1166 src/xplane.c:1172
 msgid   "Tug cab view"
 msgstr  ""
 
@@ -345,96 +346,98 @@ msgstr  ""
 msgid   "Slide this bar to move the magic squares up or down."
 msgstr  ""
 
-#: src/bp.c:2344 src/bp.c:2359
+#: src/bp.c:2344 src/bp.c:2359 src/bp.c:2361
 msgid   "Waiting for the parking brakes release"
 msgstr  ""
 
 #: src/bp.c:2493 src/bp.c:3474 src/bp.c:2497 src/bp.c:3478 src/bp.c:2514
-#: src/bp.c:3499
+#: src/bp.c:3499 src/bp.c:2516 src/bp.c:3501
 msgid   "Waiting for the parking brakes set"
 msgstr  ""
 
-#: src/bp.c:3433 src/bp.c:3437 src/bp.c:3454
+#: src/bp.c:3433 src/bp.c:3437 src/bp.c:3454 src/bp.c:3456
 msgid   "Push-back called"
 msgstr  ""
 
-#: src/bp.c:3438 src/bp.c:3442 src/bp.c:3459
+#: src/bp.c:3438 src/bp.c:3442 src/bp.c:3459 src/bp.c:3461
 msgid   "Driving to the aircraft"
 msgstr  ""
 
 #: src/bp.c:3442 src/bp.c:3446 src/bp.c:3450 src/bp.c:3463 src/bp.c:3467
+#: src/bp.c:3465 src/bp.c:3469
 msgid   "Waiting for doors/GPU/ASU closed/disconnected"
 msgstr  ""
 
-#: src/bp.c:3448 src/bp.c:3452 src/bp.c:3470
+#: src/bp.c:3448 src/bp.c:3452 src/bp.c:3470 src/bp.c:3472
 msgid   "Opening the cradle"
 msgstr  ""
 
-#: src/bp.c:3478 src/bp.c:3482 src/bp.c:3503
+#: src/bp.c:3478 src/bp.c:3482 src/bp.c:3503 src/bp.c:3505
 msgid   "Connecting to the aircraft"
 msgstr  ""
 
-#: src/bp.c:3490 src/bp.c:3494 src/bp.c:3515
+#: src/bp.c:3490 src/bp.c:3494 src/bp.c:3515 src/bp.c:3517
 msgid   "Connected to the aircraft"
 msgstr  ""
 
-#: src/bp.c:3494 src/bp.c:3498 src/bp.c:3519
+#: src/bp.c:3494 src/bp.c:3498 src/bp.c:3519 src/bp.c:3521
 msgid   "Push-back started"
 msgstr  ""
 
-#: src/bp.c:3524 src/bp.c:3528 src/bp.c:3550
+#: src/bp.c:3524 src/bp.c:3528 src/bp.c:3550 src/bp.c:3552
 msgid   "Push-back in progress"
 msgstr  ""
 
-#: src/bp.c:3528 src/bp.c:3532 src/bp.c:3554
+#: src/bp.c:3528 src/bp.c:3532 src/bp.c:3554 src/bp.c:3556
 msgid   "Push-back stopping"
 msgstr  ""
 
-#: src/bp.c:3532 src/bp.c:3536 src/bp.c:3559
+#: src/bp.c:3532 src/bp.c:3536 src/bp.c:3559 src/bp.c:3561
 msgid   "Push-back stopped"
 msgstr  ""
 
-#: src/bp.c:3536 src/bp.c:3540 src/bp.c:3563
+#: src/bp.c:3536 src/bp.c:3540 src/bp.c:3563 src/bp.c:3565
 msgid   "Lowering the nose"
 msgstr  ""
 
-#: src/bp.c:3540 src/bp.c:3544 src/bp.c:3567
+#: src/bp.c:3540 src/bp.c:3544 src/bp.c:3567 src/bp.c:3569
 msgid   "Ungrabbing the nose"
 msgstr  ""
 
-#: src/bp.c:3544 src/bp.c:3548 src/bp.c:3571
+#: src/bp.c:3544 src/bp.c:3548 src/bp.c:3571 src/bp.c:3573
 msgid   "Waiting the OK to disconnect"
 msgstr  ""
 
-#: src/bp.c:3548 src/bp.c:3552 src/bp.c:3575
+#: src/bp.c:3548 src/bp.c:3552 src/bp.c:3575 src/bp.c:3577
 msgid   "Disconnecting the tug away from the aircraft"
 msgstr  ""
 
-#: src/bp.c:3589 src/bp.c:3593 src/bp.c:3616
+#: src/bp.c:3589 src/bp.c:3593 src/bp.c:3616 src/bp.c:3618
 msgid   "Closing the cradle"
 msgstr  ""
 
 #: src/bp.c:3593 src/bp.c:3597 src/bp.c:3601 src/bp.c:3620 src/bp.c:3624
+#: src/bp.c:3622 src/bp.c:3626
 msgid   "Moving to the side of the aircraft"
 msgstr  ""
 
-#: src/bp.c:3604 src/bp.c:3608 src/bp.c:3631
+#: src/bp.c:3604 src/bp.c:3608 src/bp.c:3631 src/bp.c:3633
 msgid   "Showing the pin and the clear signal"
 msgstr  ""
 
-#: src/bp.c:3608 src/bp.c:3612 src/bp.c:3635
+#: src/bp.c:3608 src/bp.c:3612 src/bp.c:3635 src/bp.c:3637
 msgid   "Driving the tug away back to his station"
 msgstr  ""
 
-#: src/bp.c:2311 src/bp.c:2325
+#: src/bp.c:2311 src/bp.c:2325 src/bp.c:2327
 msgid   "Connected to the aircraft, waiting for clearance"
 msgstr  ""
 
-#: src/bp.c:3486 src/bp.c:3490 src/bp.c:3511
+#: src/bp.c:3486 src/bp.c:3490 src/bp.c:3511 src/bp.c:3513
 msgid   "Lifting the aircraft"
 msgstr  ""
 
-#: src/bp.c:3482 src/bp.c:3486 src/bp.c:3507
+#: src/bp.c:3482 src/bp.c:3486 src/bp.c:3507 src/bp.c:3509
 msgid   "Grabbing the aircraft"
 msgstr  ""
 
@@ -447,11 +450,11 @@ msgid   "The push process is always halted when the tug is at the nose of the "
         "command."
 msgstr  ""
 
-#: src/xplane.c:979
+#: src/xplane.c:979 src/xplane.c:981
 msgid   "Open preference window."
 msgstr  ""
 
-#: src/bp.c:3430 src/bp.c:3434 src/bp.c:3451
+#: src/bp.c:3430 src/bp.c:3434 src/bp.c:3451 src/bp.c:3453
 msgid   "Push-back waiting to be called"
 msgstr  ""
 
@@ -499,26 +502,26 @@ msgstr  ""
 msgid   "Start/Pause the manual push back"
 msgstr  ""
 
-#: src/xplane.c:993
+#: src/xplane.c:993 src/xplane.c:995
 msgid   "Start/Pause the manual push back (yoke not used)"
 msgstr  ""
 
 msgid   "Reverse the trajectory of the push back"
 msgstr  ""
 
-#: src/xplane.c:991
+#: src/xplane.c:991 src/xplane.c:993
 msgid   "Start/Pause the manual push back with yoke"
 msgstr  ""
 
-#: src/xplane.c:985
+#: src/xplane.c:985 src/xplane.c:987
 msgid   "Turn the tug to the left"
 msgstr  ""
 
-#: src/xplane.c:987
+#: src/xplane.c:987 src/xplane.c:989
 msgid   "Turn the tug to the right"
 msgstr  ""
 
-#: src/xplane.c:989
+#: src/xplane.c:989 src/xplane.c:991
 msgid   "Toggle the trajectory of the push back"
 msgstr  ""
 

--- a/src/bp.c
+++ b/src/bp.c
@@ -1572,6 +1572,8 @@ bp_delete_all_segs(void) {
     seg_t *seg;
     while ((seg = list_remove_head(&bp.segs)) != NULL)
         free(seg);
+    if (!slave_mode)
+        plan_complete = B_FALSE;
 }
 
 bool_t

--- a/src/bp.c
+++ b/src/bp.c
@@ -1573,7 +1573,7 @@ bp_delete_all_segs(void) {
     while ((seg = list_remove_head(&bp.segs)) != NULL)
         free(seg);
     if (!slave_mode)
-        plan_complete = B_FALSE;
+        plan_complete = B_FALSE; /* BP_DATAREF plan_complete */
 }
 
 bool_t
@@ -1925,7 +1925,7 @@ bp_complete(void) {
     bp_connected = B_FALSE;
     bp_conf_set_save_enabled(!bp_started);
     late_plan_requested = B_FALSE;
-    plan_complete = B_FALSE;
+    plan_complete = B_FALSE; /* BP_DATAREF plan_complete */
 
     if (bp_ls.tug != NULL) {
         tug_free(bp_ls.tug);
@@ -1958,7 +1958,7 @@ bp_complete(void) {
 static bool_t
 late_plan_end_cond(void) {
     return ((!slave_mode && list_head(&bp.segs) != NULL &&
-             !bp_cam_is_running()) || (slave_mode && plan_complete));
+            !bp_cam_is_running()) || (slave_mode && plan_complete)); /* BP_DATAREF plan_complete */
 }
 
 static bool_t
@@ -2335,7 +2335,7 @@ pb_step_lift(void) {
              * we need to save it now.
              */
             if (!slave_mode) {
-                plan_complete = B_TRUE;
+                plan_complete = B_TRUE; /* BP_DATAREF plan_complete */
                 route_save(&bp.segs);
             }
         }

--- a/src/bp_cam.c
+++ b/src/bp_cam.c
@@ -1379,9 +1379,9 @@ bp_cam_start(void)
     }
 
     cam_inited = B_TRUE;
-    planner_open = B_TRUE;
+    planner_open = B_TRUE; /* BP_DATAREF planner_open */
     if (!slave_mode)
-        plan_complete = B_FALSE;
+        plan_complete = B_FALSE; /* BP_DATAREF plan_complete */
 
     updateAvailable = getPluginUpdateStatus();
     if (updateAvailable != NULL)
@@ -1439,14 +1439,14 @@ bp_cam_stop(void)
     }
     dr_seti(&drs.use_real_wx, saved_real_wx);
     cam_inited = B_FALSE;
-    planner_open = B_FALSE;
+    planner_open = B_FALSE; /* BP_DATAREF planner_open */
 
     pop_fov_values();
     eye_track_fini();
     clear_bottom_msg();
 
     if (!slave_mode)
-        plan_complete = (list_head(&bp.segs) != NULL);
+        plan_complete = (list_head(&bp.segs) != NULL); /* BP_DATAREF plan_complete */
 
     return (B_TRUE);
 }

--- a/src/bp_cam.c
+++ b/src/bp_cam.c
@@ -1379,6 +1379,7 @@ bp_cam_start(void)
     }
 
     cam_inited = B_TRUE;
+    planner_open = B_TRUE;
     if (!slave_mode)
         plan_complete = B_FALSE;
 
@@ -1438,6 +1439,7 @@ bp_cam_stop(void)
     }
     dr_seti(&drs.use_real_wx, saved_real_wx);
     cam_inited = B_FALSE;
+    planner_open = B_FALSE;
 
     pop_fov_values();
     eye_track_fini();

--- a/src/bp_cam.c
+++ b/src/bp_cam.c
@@ -1379,6 +1379,8 @@ bp_cam_start(void)
     }
 
     cam_inited = B_TRUE;
+    if (!slave_mode)
+        plan_complete = B_FALSE;
 
     updateAvailable = getPluginUpdateStatus();
     if (updateAvailable != NULL)
@@ -1440,6 +1442,9 @@ bp_cam_stop(void)
     pop_fov_values();
     eye_track_fini();
     clear_bottom_msg();
+
+    if (!slave_mode)
+        plan_complete = (list_head(&bp.segs) != NULL);
 
     return (B_TRUE);
 }

--- a/src/tug.c
+++ b/src/tug.c
@@ -151,6 +151,18 @@ typedef struct {
  *	same time as the driver, i.e. the cab either raises or lowers
  *	depending on the direction the tug is moving (down - forward, up -
  *	backward).
+ * bp/anim/winch_on: 0/1: for winch-style tugs, this is 1 while the winch
+ *	mechanism is pulling cable or otherwise engaged.
+ * bp/anim/clear_signal: -1/0/1: BP displays a marshaller-style clear signal
+ *	as the push finishes. 0 hides the gestures, 1 plays the "clear right"
+ *	animation and -1 plays the "clear left" variant.
+ * bp/anim/lift_in_transit: 0/1: becomes 1 whenever the cradle or tire-sense
+ *	arms are actively moving and drops back to 0 once they stop.
+ * bp/anim/beacon_flash: 0/1: flashes at the configured beacon flash rate
+ *	whenever bp/anim/hazard_lights is 1.
+ * bp/anim/tug_pos_x/y/z: world-space coordinates of the tug draw origin in
+ *	X-Plane local meters. These are provided so OBJ animations can offset
+ *	external equipment relative to the tug's actual location and terrain.
  */
 
 static anim_info_t anim[TUG_NUM_ANIMS] = {

--- a/src/xplane.c
+++ b/src/xplane.c
@@ -150,8 +150,9 @@ static XPLMFlightLoopID reload_floop_ID = NULL;
  *   1 on the slave before engaging the tug. We must not change roles mid-run.
  * - "bp/op_complete": boolean the master toggles when pushback should end.
  *   The slave watches this to jump to PB_STEP_STOPPING/bp_complete().
- * - "bp/plan_complete": master-side flag that late-planning has finished so
- *   the slave may continue past the late-plan gate even without segments.
+ * - "bp/plan_complete": master-side flag that flips to 1 as soon as a valid
+ *   pushback plan exists (route saved or late-plan completed). Slaves can
+ *   use this to continue past the late-plan gate even without segments.
  * - "bp/planner_open" (read-only): indicates whether the planner UI is shown.
  *   Helpful for UI sync and for deciding which SmartCopilot controls to hide.
  * - "bp/tug_name": string identifying the exact tug picked on the master.

--- a/src/xplane.c
+++ b/src/xplane.c
@@ -138,40 +138,33 @@ static XPLMCreateFlightLoop_t reload_floop = {
 static XPLMFlightLoopID reload_floop_ID = NULL;
 
 /*
- * These datarefs are for syncing two instances of BetterPushback over the
- * net via syncing addons such as smartcopilot and Shared Flight.
- * This works as follows:
- * 1) Master/slave must not be switched during pushback (undefined behavior
- *	may result). It's possible to observe if BetterPushback is running by
- *	monitoring the read-only boolean "bp/started" dataref. This dataref
- *	must NOT be synced, it's only a hint to smartcopilot whether
- *	switching is safe.
- * 2) The boolean dataref "bp/slave_mode" must be set to 0 on the master and
- *	1 on the slave.
- * 3) The boolean dataref "bp/op_complete" must be synced from master to
- *	slave. This signals to bp_run() that the pushback stage needs to
- *	progress to either PB_STEP_STOPPING if the tug has already attached,
- *	or immediately to bp_complete() if it has not. The master sets this
- *	dataref in response to either a "Stop" command request, or when it
- *	has processed all pushback segments. The slave cannot set this
- *	(master controls when pushback stops).
- * 4) The boolean dataref "bp/plan_complete" must be synced from master to
- *	slave. This is a signal from the master machine to the slave that
- *	if late_plan_requested was in effect, the slave can continue with
- *	the state transitions past the late_plan_requested limit. This is
- *	needed because we don't transfer the route to the slave, so the
- *	slave cannot use the presence of a route as a condition to continue.
- * 5) The string dataref "bp/tug_name" must be synced from master to slave.
- *	This string identifies which tug model the master selected (since tug
- *	selection is non-deterministic). The slave then instances its tug
- *	object using tug_alloc_man. Both master and slave must have identical
- *	tug libraries, otherwise sync fails.
- * 6) The command "BetterPushback/start" should be synced from mater to slave.
- *	There's no need to sync any other commands. The planning GUI is
- *	disabled on the slave machine and stopping of the pushback can only be
- *	performed by the master machine.
- * 7) The dataref bp/parking_brake_override can be set to 1 on slaves and
- *  then bp/parking_brake_set will be used instead of the local parking brake.
+ * These datarefs are surfaced so that coupling add-ons (SmartCopilot,
+ * SharedFlight, etc.) can keep two copies of BetterPushback in sync. The
+ * expected behaviour of each dataref/command is:
+ *
+ * - "bp/started" (read-only): goes to 1 when pushback logic is running.
+ *   Use it only as a hint for whether switching master/slave roles is safe.
+ * - "bp/connected" (read-only): becomes 1 once the tug is fully attached.
+ *   This mirrors the local PB_STEP_CONNECTED state for remote clients.
+ * - "bp/slave_mode": writable flag that must be set to 0 on the master and
+ *   1 on the slave before engaging the tug. We must not change roles mid-run.
+ * - "bp/op_complete": boolean the master toggles when pushback should end.
+ *   The slave watches this to jump to PB_STEP_STOPPING/bp_complete().
+ * - "bp/plan_complete": master-side flag that late-planning has finished so
+ *   the slave may continue past the late-plan gate even without segments.
+ * - "bp/planner_open" (read-only): indicates whether the planner UI is shown.
+ *   Helpful for UI sync and for deciding which SmartCopilot controls to hide.
+ * - "bp/tug_name": string identifying the exact tug picked on the master.
+ *   Both sides need an identical tug library for deterministic behaviour.
+ * - "bp/parking_brake_override": when set to 1 on a slave, BetterPushback
+ *   reads the boolean "bp/parking_brake_set" instead of the local brake
+ *   dataref. This allows remote hardware (or a master instance) to signal
+ *   the brake state explicitly.
+ *
+ * Commands: mirror the "BetterPushback/start" command from master to slave.
+ * The other commands remain local – the slave GUI stays disabled and only
+ * the master can stop a pushback. Master/slave assignments should therefore
+ * be established before either instance enters the pushback state machine.
  */
 static dr_t bp_started_dr, bp_connected_dr, slave_mode_dr, op_complete_dr;
 static dr_cfg_t slave_mode_dr_cfg ;
@@ -182,8 +175,8 @@ bool_t bp_started = B_FALSE;
 bool_t bp_connected = B_FALSE;
 bool_t slave_mode = B_FALSE;
 bool_t op_complete = B_FALSE;
-bool_t plan_complete = B_FALSE;
-bool_t planner_open = B_FALSE;
+bool_t plan_complete = B_FALSE; /* BP_DATAREF plan_complete */
+bool_t planner_open = B_FALSE;  /* BP_DATAREF planner_open */
 bool_t pb_set_remote = B_FALSE;
 bool_t pb_set_override = B_FALSE;
 char bp_tug_name[64] = {0};
@@ -290,8 +283,8 @@ init_core_state(void)
     bp_connected = B_FALSE;
     slave_mode = B_FALSE;
     op_complete = B_FALSE;
-    plan_complete = B_FALSE;
-    planner_open = B_FALSE;
+    plan_complete = B_FALSE; /* BP_DATAREF plan_complete */
+    planner_open = B_FALSE;  /* BP_DATAREF planner_open */
     cab_view_init();
 }
 
@@ -1009,9 +1002,9 @@ XPluginStart(char *name, char *sig, char *desc)
     dr_create_i(&op_complete_dr, (int *)&op_complete, B_TRUE,
                 "bp/op_complete");
     dr_create_i(&plan_complete_dr, (int *)&plan_complete, B_TRUE,
-                "bp/plan_complete");
+                "bp/plan_complete"); /* BP_DATAREF plan_complete */
     dr_create_i(&planner_open_dr, (int *)&planner_open, B_FALSE,
-                "bp/planner_open");
+                "bp/planner_open"); /* BP_DATAREF planner_open */
     dr_create_b(&bp_tug_name_dr, bp_tug_name, sizeof(bp_tug_name),
                 B_TRUE, "bp/tug_name");
 
@@ -1045,8 +1038,8 @@ XPluginStop(void)
     dr_delete(&bp_started_dr);
     dr_delete(&slave_mode_dr);
     dr_delete(&op_complete_dr);
-    dr_delete(&plan_complete_dr);
-    dr_delete(&planner_open_dr);
+    dr_delete(&plan_complete_dr); /* BP_DATAREF plan_complete */
+    dr_delete(&planner_open_dr);  /* BP_DATAREF planner_open */
     dr_delete(&bp_tug_name_dr);
     dr_delete(&pb_set_remote_dr);
     dr_delete(&pb_set_override_dr);

--- a/src/xplane.c
+++ b/src/xplane.c
@@ -175,7 +175,7 @@ static XPLMFlightLoopID reload_floop_ID = NULL;
  */
 static dr_t bp_started_dr, bp_connected_dr, slave_mode_dr, op_complete_dr;
 static dr_cfg_t slave_mode_dr_cfg ;
-static dr_t plan_complete_dr, bp_tug_name_dr;
+static dr_t plan_complete_dr, planner_open_dr, bp_tug_name_dr;
 static dr_t pb_set_remote_dr, pb_set_override_dr;
 static dr_cfg_t pb_set_remote_dr_cfg, pb_set_override_dr_cfg;
 bool_t bp_started = B_FALSE;
@@ -183,6 +183,7 @@ bool_t bp_connected = B_FALSE;
 bool_t slave_mode = B_FALSE;
 bool_t op_complete = B_FALSE;
 bool_t plan_complete = B_FALSE;
+bool_t planner_open = B_FALSE;
 bool_t pb_set_remote = B_FALSE;
 bool_t pb_set_override = B_FALSE;
 char bp_tug_name[64] = {0};
@@ -290,6 +291,7 @@ init_core_state(void)
     slave_mode = B_FALSE;
     op_complete = B_FALSE;
     plan_complete = B_FALSE;
+    planner_open = B_FALSE;
     cab_view_init();
 }
 
@@ -1008,6 +1010,8 @@ XPluginStart(char *name, char *sig, char *desc)
                 "bp/op_complete");
     dr_create_i(&plan_complete_dr, (int *)&plan_complete, B_TRUE,
                 "bp/plan_complete");
+    dr_create_i(&planner_open_dr, (int *)&planner_open, B_FALSE,
+                "bp/planner_open");
     dr_create_b(&bp_tug_name_dr, bp_tug_name, sizeof(bp_tug_name),
                 B_TRUE, "bp/tug_name");
 
@@ -1041,6 +1045,8 @@ XPluginStop(void)
     dr_delete(&bp_started_dr);
     dr_delete(&slave_mode_dr);
     dr_delete(&op_complete_dr);
+    dr_delete(&plan_complete_dr);
+    dr_delete(&planner_open_dr);
     dr_delete(&bp_tug_name_dr);
     dr_delete(&pb_set_remote_dr);
     dr_delete(&pb_set_override_dr);

--- a/src/xplane.c
+++ b/src/xplane.c
@@ -66,14 +66,14 @@ static bool_t inited = B_FALSE;
 XPLMCommandRef start_pb, start_cam, conn_first, stop_pb;
 static XPLMCommandRef stop_cam;
 static XPLMCommandRef cab_cam, recreate_routes;
-static XPLMCommandRef abort_push, pref_cmd;
+static XPLMCommandRef abort_push, pref_cmd, reload_cmd;
 static XPLMCommandRef manual_push_start, manual_push_start_no_yoke;
 static XPLMCommandRef manual_push_left, manual_push_right, manual_push_reverse;
 static XPLMMenuID root_menu;
 static int plugins_menu_item;
 static int start_pb_plan_menu_item, stop_pb_plan_menu_item;
 static int start_pb_menu_item, stop_pb_menu_item, conn_first_menu_item;
-static int cab_cam_menu_item, prefs_menu_item;
+static int cab_cam_menu_item, prefs_menu_item, reload_menu_item;
 static bool_t prefs_enable, stop_pb_plan_enable,
     stop_pb_enable, conn_first_enable, cab_cam_enable;
 bool_t start_pb_plan_enable, start_pb_enable;
@@ -99,6 +99,8 @@ static int cab_cam_handler(XPLMCommandRef, XPLMCommandPhase, void *);
 static int recreate_routes_handler(XPLMCommandRef, XPLMCommandPhase, void *);
 
 static int abort_push_handler(XPLMCommandRef, XPLMCommandPhase, void *);
+
+static int reload_handler(XPLMCommandRef, XPLMCommandPhase, void *);
 
 static int manual_push_left_handler(XPLMCommandRef, XPLMCommandPhase, void *);
 static int manual_push_right_handler(XPLMCommandRef, XPLMCommandPhase, void *);
@@ -163,9 +165,11 @@ static XPLMFlightLoopID reload_floop_ID = NULL;
  *   the brake state explicitly.
  *
  * Commands: mirror the "BetterPushback/start" command from master to slave.
- * The other commands remain local – the slave GUI stays disabled and only
- * the master can stop a pushback. Master/slave assignments should therefore
- * be established before either instance enters the pushback state machine.
+ * The other commands remain local (including "BetterPushback/reload") – the
+ * slave GUI stays disabled and only the master can stop a pushback. Reload
+ * is only safe when pushback is idle and planner/prefs are closed.
+ * Master/slave assignments should therefore be established before either
+ * instance enters the pushback state machine.
  */
 static dr_t bp_started_dr, bp_connected_dr, slave_mode_dr, op_complete_dr;
 static dr_cfg_t slave_mode_dr_cfg ;
@@ -292,7 +296,11 @@ init_core_state(void)
 static void
 enable_menu_items()
 {
+    bool_t reload_enable = (!bp_started && !planner_open &&
+        !get_pref_widget_status());
+
     XPLMEnableMenuItem(root_menu, prefs_menu_item, prefs_enable);
+    XPLMEnableMenuItem(root_menu, reload_menu_item, reload_enable);
     XPLMEnableMenuItem(root_menu, start_pb_menu_item, start_pb_enable);
     XPLMEnableMenuItem(root_menu, stop_pb_menu_item, stop_pb_enable);
     XPLMEnableMenuItem(root_menu, start_pb_plan_menu_item, start_pb_plan_enable);
@@ -676,6 +684,24 @@ preference_window_handler(XPLMCommandRef cmd, XPLMCommandPhase phase, void *refc
     return (1);
 }
 
+static int
+reload_handler(XPLMCommandRef cmd, XPLMCommandPhase phase, void *refcon)
+{
+    UNUSED(cmd);
+    UNUSED(refcon);
+    if (phase != xplm_CommandEnd)
+        return (0);
+
+    if (bp_started || planner_open || get_pref_widget_status())
+    {
+        logMsg(BP_WARN_LOG "Command \"BetterPushback/reload\" is currently disabled");
+        return (0);
+    }
+
+    bp_sched_reload();
+    return (1);
+}
+
 static void
 menu_cb(void *inMenuRef, void *inItemRef)
 {
@@ -973,6 +999,9 @@ XPluginStart(char *name, char *sig, char *desc)
     pref_cmd = XPLMCreateCommand(
         "BetterPushback/preference",
         _("Open preference window."));
+    reload_cmd = XPLMCreateCommand(
+        "BetterPushback/reload",
+        _("Reload BetterPushback"));
 
     abort_push = XPLMCreateCommand("BetterPushback/abort_push",
                                    _("Abort pushback during coupled push"));
@@ -1139,6 +1168,7 @@ bp_priv_enable(void)
                                1, NULL);
     XPLMRegisterCommandHandler(pref_cmd, preference_window_handler,
                                1, NULL);
+    XPLMRegisterCommandHandler(reload_cmd, reload_handler, 1, NULL);
     XPLMRegisterCommandHandler(abort_push, abort_push_handler, 1, NULL);
 
     XPLMRegisterCommandHandler(manual_push_left, manual_push_left_handler, 1, NULL);
@@ -1168,6 +1198,8 @@ bp_priv_enable(void)
     XPLMAppendMenuSeparator(root_menu);
     prefs_menu_item = XPLMAppendMenuItemWithCommand(root_menu,
                                                     _("Preferences..."), pref_cmd);
+    reload_menu_item = XPLMAppendMenuItemWithCommand(root_menu,
+                                                     _("Reload BetterPushback"), reload_cmd);
 
     tug_starts_next_plane = B_FALSE;
     (void) conf_get_b(bp_conf,"tug_starts_next_plane", &tug_starts_next_plane);
@@ -1236,6 +1268,7 @@ bp_priv_disable(void)
     XPLMUnregisterCommandHandler(manual_push_start, manual_push_start_handler, 1, NULL);
     XPLMUnregisterCommandHandler(manual_push_start_no_yoke, manual_push_start_no_yoke_handler, 1, NULL);
     XPLMUnregisterCommandHandler(pref_cmd, preference_window_handler, 1, NULL);
+    XPLMUnregisterCommandHandler(reload_cmd, reload_handler, 1, NULL);
 
     bp_fini();
     tug_glob_fini();

--- a/src/xplane.h
+++ b/src/xplane.h
@@ -42,8 +42,8 @@ extern bool_t slave_mode;
 extern bool_t pb_set_remote;
 extern bool_t pb_set_override;
 extern bool_t op_complete;
-extern bool_t plan_complete;
-extern bool_t planner_open;
+extern bool_t plan_complete; /* BP_DATAREF plan_complete */
+extern bool_t planner_open;  /* BP_DATAREF planner_open */
 extern char bp_tug_name[64];
 
 extern airportdb_t *airportdb;

--- a/src/xplane.h
+++ b/src/xplane.h
@@ -43,6 +43,7 @@ extern bool_t pb_set_remote;
 extern bool_t pb_set_override;
 extern bool_t op_complete;
 extern bool_t plan_complete;
+extern bool_t planner_open;
 extern char bp_tug_name[64];
 
 extern airportdb_t *airportdb;


### PR DESCRIPTION
1. Added a safe reload command BetterPushback/reload plus a menu item. The reload is only enabled when pushback is idle (no active pushback, planner closed, prefs window closed) to avoid unsafe state transitions.
2. Improved coupling/sync behavior for multi‑crew add‑ons: bp/plan_complete is now a master‑only signal that flips to 1 as soon as a valid plan exists (route saved or late‑plan completed) and clears when the plan is invalidated. Slaves can use this to pass the late‑plan gate even without route segments.
3. Added read‑only bp/planner_open to expose planner UI state for external sync/UX logic.