### PR TITLE
Apply owner-requested Ground Operations corrections

### DIFF
--- a/GROUND_OPS_UI_DESIGN.md
+++ b/GROUND_OPS_UI_DESIGN.md
@@ -1,7 +1,7 @@
 # Ground Operations UI Design
 
-Status: approved product direction; Phases 3 and 4 accepted
-Last updated: 2026-08-04
+Status: approved product direction; reconciled with owner review
+Last updated: 2026-09-04
 
 ## Purpose
 
@@ -43,8 +43,9 @@ cockpit.
   distinct operations.
 - **Offline first:** network connectivity must never prevent an ordinary
   manual pushback.
-- **No physics regression:** the tested push controller remains separate from
-  the UI and ground-operations workflow.
+- **No physics regression:** motion uses the upstream legacy planner,
+  `drive_segs` steering, turn/endpoint behavior, and tug approach geometry.
+  Ground Operations does not modify that path.
 
 ## Window modes
 
@@ -58,7 +59,8 @@ cockpit.
 ### Compact progress rail
 
 - Default active mode.
-- Nominal size at 100 percent UI scale: 58 by 244 boxels.
+- Nominal size on Windows/Linux: 58 by 244 boxels. macOS uses a proportional
+  1.35 scale (78 by 329), including text and hit targets.
 - Contains the same Tug, Connect, Comms, Push, and Clear nodes used by the
   expanded panel, without any additional dashboard content.
 - Completed stages are filled, the current stage is highlighted, and future
@@ -75,9 +77,8 @@ cockpit.
 
 ### Expanded panel
 
-- Nominal width at 100 percent UI scale: 292 boxels.
-- Allowed width after scaling: 280 to 340 boxels.
-- Content-driven height, normally 320 to 410 boxels.
+- Nominal fixed size on Windows/Linux: 292 by 420 boxels. macOS uses a
+  proportional 1.35 scale (394 by 567), including text and hit targets.
 - Narrow vertical layout with a five-stage rail on the left.
 - The upper-left grip/title region moves the window.
 - The upper-right control collapses directly to the compact rail.
@@ -121,15 +122,15 @@ Required behavior:
   exists.
 - Respect X-Plane UI scaling and high-DPI coordinates.
 
-Initial preference keys are expected to cover:
+Persisted UI state covers:
 
 - presentation mode: hidden, compact rail, or panel;
 - floating geometry;
 - popped-out operating-system geometry;
-- preferred monitor;
-- UI scale;
-- completed-operation auto-hide delay;
-- keep-compact-rail-visible option.
+- preferred monitor.
+
+Platform scale is selected at build time. Windows/Linux use 1.0; macOS uses
+1.35. A development build can enable `BP_EMULATE_MAC_UI_SCALE`.
 
 Exact key names are an implementation detail, but configuration migration must
 be backward compatible.
@@ -151,14 +152,14 @@ states into it. The UI must never infer motion merely from a caption string.
 | `PB_STEP_DRIVING_UP_CONNECT` | Connect | Positioning tug to connect | No |
 | `PB_STEP_GRABBING` | Connect | Securing the nose gear | No |
 | `PB_STEP_LIFTING` | Comms while awaiting plan, then Connect while lifting | Tug connected; plan the push, then Lifting the nose gear | Amber Plan push after capture and before lift |
-| `PB_STEP_CONNECTED` | Comms | Ready for brake release, or late plan required | Yes: release brake or complete plan |
+| `PB_STEP_CONNECTED` | Comms | Ready for brake release, or late plan required | Change plan while the parking brake is set; otherwise release brake or complete plan |
 | `PB_STEP_STARTING` | Push | Starting pushback | No |
 | `PB_STEP_PUSHING` | Push | Pushback in progress, Pausing, or Pushback paused | Pause/Resume plus confirmed End operation |
 | `PB_STEP_STOPPING` | Push | Stopping the aircraft | No |
 | `PB_STEP_STOPPED` | Push | Aircraft stopped | Yes: set parking brake |
 | `PB_STEP_LOWERING` | Clear | Lowering the nose gear | No |
 | `PB_STEP_UNGRABBING` | Clear | Releasing the nose gear | No |
-| `PB_STEP_WAITING4OK2DISCO` | Clear | Ready to disconnect | Yes: confirm tug disconnection |
+| `PB_STEP_WAITING4OK2DISCO` | Clear | Disconnecting the tug | No; disconnect is automatic |
 | `PB_STEP_MOVING_AWAY` | Clear | Tug moving clear | No |
 | `PB_STEP_CLOSING_CRADLE` | Clear | Closing the tug cradle | No |
 | `PB_STEP_STARTING2CLEAR` | Clear | Driver moving to clear | No |
@@ -235,7 +236,7 @@ The UI must not fabricate a flight identity or weather value.
   route slots are available per published gate and compatible aircraft profile.
 - An arbitrary or saved-situation start remains usable for the current session,
   but it cannot list, load, save, or modify persistent gate-route slots.
-- The planner's blue controller trajectory and magenta danger band remain visual
+- The planner's blue legacy route and magenta danger band remain visual
   review tools and do not claim automatic obstacle clearance.
 
 ### Brake release
@@ -343,13 +344,14 @@ state. The stationary hold freezes steering and cannot resume through a set
 parking brake. End operation uses the compatible terminating stop path and
 discards the route only after confirmation.
 
-The Ground Operations panel is the fork's only default operational interface.
+The Ground Operations panel is the fork's standard operational interface.
 The original four "magic squares" windows remain preserved in `bp.c`, but the
 build defaults `BP_ENABLE_LEGACY_MAGIC_SQUARES` to `OFF` so duplicate controls
 are not rendered. Configuring that CMake option `ON` restores the original
 windows for upstream compatibility. The switch affects presentation only:
 automatic beacon-triggered tug behavior is evaluated separately, and the
-planner, preferences, commands, and disconnect/reconnect prompts are unchanged.
+planner, preferences, and commands remain available. The final disconnection
+is automatic; the old disconnect/reconnect window source is dormant.
 
 ## Performance contract
 
@@ -367,9 +369,9 @@ planner, preferences, commands, and disconnect/reconnect prompts are unchanged.
 
 The Phase 3 implementation quantizes speed to 0.1 m/s and remaining distance to
 whole meters before comparing inputs. Metric-only changes update the snapshot
-without producing semantic transition logs. The optional
-`ground_ops_captions_enabled` preference mirrors an issued crew message only for
-that message's audio duration, including when simulator sound is disabled.
+without producing semantic transition logs. Captions are always enabled and
+mirror an issued crew message only for that message's audio duration, including
+when simulator sound is disabled.
 
 The late-plan pre-lift hold is exposed explicitly rather than inferred from
 `PB_STEP_LIFTING`: once nose-gear capture is complete, the UI advances to Comms

--- a/NEXT_SESSION_HANDOFF.md
+++ b/NEXT_SESSION_HANDOFF.md
@@ -1,13 +1,20 @@
 # BetterPushback next-session handoff
 
+> Superseded on 2026-09-04 by the owner-review reconciliation. Historical
+> hashes and simulator-accepted experiments below remain useful evidence, but
+> they are not the current release candidate. The active branch now restores
+> upstream legacy path motion, automatic disconnect, the original per-aircraft
+> plugin exclusion, connected-hold replanning, and proportional macOS Ground
+> Operations scaling.
+
 Prepared: 2026-08-08
 Workspace: `C:\Users\DARRON\OneDrive\Documents\BetterPushBack\BetterPusbackMod`
 Branch: `feature/realistic-tug-physics`
 
 ## Start here
 
-The completed Ground Operations UI and Emergency Tow workflow are the
-**simulator-accepted baseline** at current `HEAD`. The fork now presents only
+The completed Ground Operations UI and Emergency Tow workflow were the
+**simulator-accepted baseline** at the recorded historical commit. The fork presents only
 the Ground Operations panel by default while preserving the original
 operational UI behind a reversible build option.
 

--- a/OWNER_REVIEW_CHECKLIST.md
+++ b/OWNER_REVIEW_CHECKLIST.md
@@ -1,0 +1,48 @@
+# Owner review checklist
+
+This checklist covers the reconciliation requested on 2026-09-04. Automated
+tests validate state mapping, route helpers, and both UI scale modes; the final
+visual and motion checks require X-Plane.
+
+## Build and UI
+
+- Build macOS normally. The Ground Operations rail should be 78 by 329 and the
+  panel 394 by 567, with fonts, spacing, controls, hit targets, and drag
+  threshold all scaled together.
+- For a Windows/Linux visual preview, run `./build_xpl.sh -m`. The normal build
+  without `-m` must remain at 58 by 244 and 292 by 420.
+- Hover every Ground Operations control. Panel tooltips must wrap and remain
+  inside the panel.
+- Confirm the Preferences window does not show Auto disconnect when done,
+  either Hide magic squares control, Magic squares position, Enable Ground
+  Operations UI, or Show Ground Operations captions.
+- Confirm ACF Plugin Exclusion (Experimental), Eye Tracker Plugin Exclusion,
+  and all other retained upstream preferences are present.
+
+## Normal operation
+
+- Draw and accept straight, single-turn, multi-turn, and forward-tow routes.
+  Compare planner construction, steering, turn transitions, tug approach, and
+  final stopping with the upstream legacy behavior.
+- While connected with the parking brake set, confirm **Change plan** appears
+  and reopens the planner. Release the brake and confirm the action disappears
+  before motion.
+- Pause during a straight and a turn. Confirm only longitudinal motion stops,
+  then resume and verify the same route continues.
+- Use **End operation** while moving and while held. Confirm the aircraft stops
+  and disconnects at the current position without returning to the planned
+  endpoint.
+- Complete the operation. Confirm disconnect occurs automatically and no
+  separate disconnect or reconnect windows appear.
+
+## Repeated and emergency operation
+
+- Complete normal pushback, **Call tow back**, Emergency Tow, and another
+  normal pushback without reloading the plugin.
+- Confirm Emergency Tow uses the same legacy motion engine and configured tug
+  towing-speed limits.
+- Confirm the wing-walker timing remains unchanged for a normal operation and
+  remains omitted for Emergency Tow.
+
+Record the tested commit, platform, X-Plane version, aircraft, tug, and any
+screenshots or `Log.txt` evidence before release approval.

--- a/OWNER_REVIEW_CHECKLIST.md
+++ b/OWNER_REVIEW_CHECKLIST.md
@@ -17,6 +17,9 @@ visual and motion checks require X-Plane.
   operation message must render on exactly two lines.
 - Confirm the installed package contains the wing-walker OBJ, diffuse texture,
   LIT texture, and attribution file under `objects/wing_walker`.
+- Confirm a normal build does not log `Recording pushback telemetry` and does
+  not create a new CSV in `Output/BetterPushback/telemetry`. Telemetry must be
+  present only in an explicit `./build_xpl.sh -t` diagnostic build.
 - Confirm the Preferences window does not show Auto disconnect when done,
   either Hide magic squares control, Magic squares position, Enable Ground
   Operations UI, or Show Ground Operations captions.

--- a/OWNER_REVIEW_CHECKLIST.md
+++ b/OWNER_REVIEW_CHECKLIST.md
@@ -13,6 +13,10 @@ visual and motion checks require X-Plane.
   without `-m` must remain at 58 by 244 and 292 by 420.
 - Hover every Ground Operations control. Panel tooltips must wrap and remain
   inside the panel.
+- Confirm every CURRENT TASK message remains inside its card. The completed
+  operation message must render on exactly two lines.
+- Confirm the installed package contains the wing-walker OBJ, diffuse texture,
+  LIT texture, and attribution file under `objects/wing_walker`.
 - Confirm the Preferences window does not show Auto disconnect when done,
   either Hide magic squares control, Magic squares position, Enable Ground
   Operations UI, or Show Ground Operations captions.
@@ -34,6 +38,10 @@ visual and motion checks require X-Plane.
   endpoint.
 - Complete the operation. Confirm disconnect occurs automatically and no
   separate disconnect or reconnect windows appear.
+- Confirm Ground Operations remains visible throughout an active operation.
+  After completion, taxi at or above the legacy 1 m/s threshold and confirm
+  the UI hides; slow below 1 m/s while on the ground and confirm the same
+  expanded or collapsed view returns automatically.
 
 ## Repeated and emergency operation
 

--- a/PHASE_TESTING.md
+++ b/PHASE_TESTING.md
@@ -1881,3 +1881,69 @@ prepared sibling dependency tree was supplied. A second Linux build with
 `BP_ENABLE_LEGACY_MAGIC_SQUARES=ON` also passed. Dependency bootstrap remains a
 clean-machine setup requirement, but it does not block branch publication or
 upstream source review.
+
+## Owner-feedback reconciliation validation
+
+Date completed: 2026-09-04
+Status: **Accepted on Windows after two complete simulator operations**
+
+Source commits validated:
+
+- `532c3bb58158870e691ff38de2a7e370e1a98fb4` — Ground Operations UI and
+  packaging corrections.
+- `5957b9468e6bffe0ff31c79ace2d706ee8b6cf30` — runtime telemetry disabled by
+  default.
+
+Corrections validated:
+
+- The wing-walker OBJ, diffuse texture, LIT texture, and attribution are all
+  included in the test package and the worker renders through the expected
+  hidden, STOP, STANDBY, CLEAR, hidden signal sequence.
+- The completed-operation CURRENT TASK text is constrained to exactly two
+  lines and bounded by the task card.
+- The Ground Operations window remains visible during an active operation,
+  hides after completion at the legacy 1 m/s ground-speed threshold, and
+  restores the same presentation below that threshold.
+- Normal builds no longer create per-pushback telemetry CSV files. Diagnostic
+  telemetry remains available only through the explicit
+  `BP_ENABLE_RUNTIME_TELEMETRY=ON` build option.
+
+Automated and build verification:
+
+| Check | Result |
+| --- | --- |
+| Complete regression suite, including telemetry-disabled contract | Passed |
+| Address/undefined-behavior sanitizer telemetry tests | Passed |
+| Windows native-scale warnings-as-errors release build | Passed |
+| Windows macOS-scale emulation warnings-as-errors release build | Passed |
+| Explicit telemetry-enabled diagnostic build | Passed |
+| Distribution audit: 481 non-empty files and all required assets | Passed |
+| `git diff --check` | Passed |
+
+Accepted Windows binary evidence:
+
+- Native-scale XPL SHA-256:
+  `A869B7E9407F30F3CC552A2EB46AF2E787AA87A1CB6F7A1410311D0DE743D97A`.
+- macOS-scale emulation XPL SHA-256:
+  `F08898B1A1CD627A94C545E35AADDEDC2BDC1F334D73801B67DD9816C249D78C`.
+
+Simulator validation used the ToLiss A321 V1.9.1 and AST-3F tug in two fresh
+X-Plane 12 sessions:
+
+- The first complete operation validated the restored wing walker, bounded
+  CURRENT TASK text, and repeated legacy speed-gate hide/restore behavior.
+  Panel drawing averaged 0.017 ms and peaked at 0.212 ms.
+- The second complete operation used the telemetry-disabled build. It produced
+  36 unique Ground Operations state transitions, the full wing-walker signal
+  sequence, correct speed-gate hide/restore behavior, and a clean plugin
+  shutdown. Panel drawing averaged 0.017 ms and peaked at 0.107 ms.
+- The telemetry directory remained at 62 CSV files, with its newest file still
+  dated 16:30:47 from the earlier diagnostic build. The corrected normal build
+  created no file and emitted no telemetry-recording message.
+- BetterPushback logged no errors or assertions. The existing aircraft-loading
+  and disabled `stop_planner` warnings did not affect either operation.
+
+Native macOS compilation and visual confirmation remain maintainer-side review
+items; Windows macOS-scale emulation passed before publication.
+
+Commit criterion: **Passed for upstream correction review**.

--- a/PHASE_TESTING.md
+++ b/PHASE_TESTING.md
@@ -1,5 +1,14 @@
 # Realism Fork Verification Record
 
+> This file preserves historical experiment evidence. On 2026-09-04, owner
+> review superseded the custom steering, endpoint-correction, acceleration,
+> disconnect/reconnect-prompt, and optional-Ground-Ops preferences described in
+> older phases. The current candidate uses the upstream legacy motion path,
+> mandatory automatic disconnect, always-enabled Ground Operations captions,
+> a connected-hold **Change plan** action, and platform-scaled Mac UI geometry.
+> Historical artifact hashes below must not be treated as hashes of the current
+> candidate.
+
 This is the evidence log for the realism fork. A phase is not marked complete
 until its code has passed automated checks, its Windows plugin has been built
 and installed, and its acceptance checks have been confirmed in X-Plane by a

--- a/README.md
+++ b/README.md
@@ -9,18 +9,18 @@ pushback operation. To increase immersion, it speaks to you in a variety
 of languages and accents, simulating ground staff at various places
 around the world.
 
-In this realism fork, the planner's blue line is a controller-matched preview
-of the expected main-gear trajectory rather than an ideal circular arc. A
-smooth, uniformly shaded magenta band marks the continuous, wingspan-wide
-danger zone around that trajectory. It supports visual clearance planning but
-does not perform automatic collision detection.
+In this fork, the planner and live tug use BetterPushback's original route
+construction, segment steering, turn tracking, stopping, and approach
+geometry. The planner's blue line therefore describes the legacy planned path.
+A smooth, uniformly shaded magenta band marks a wingspan-wide visual-clearance
+area around it, but does not perform automatic collision detection.
 
 Development of the compact ground-operations experience is governed by the
 tracked [UI design](GROUND_OPS_UI_DESIGN.md) and the fork's complete
 [implementation roadmap](ROADMAP.md). These documents define the approved
 five-stage compact rail, live workflow panel, performance guardrails,
-phased delivery, and acceptance gates. Active crew audio prompts can be mirrored
-as optional panel captions. Build and simulator evidence for every phase is retained in the
+phased delivery, and acceptance gates. Active crew audio prompts are mirrored
+as panel captions. Build and simulator evidence for every phase is retained in the
 [verification record](PHASE_TESTING.md).
 
 The Ground Operations workflow first displays the parsed departure-airport
@@ -45,7 +45,7 @@ the accepted route and steering state, while **End operation** stops safely and
 continues through the normal disconnect sequence at the current position.
 
 After a completed normal operation, **Call tow back** starts a guarded one-time
-Emergency Tow. The tug reconnects, the manual planner opens at the live aircraft
+Emergency Tow. The tug returns and connects, the manual planner opens at the live aircraft
 position, and the plugin returns to its normal start state after towing and
 disconnect are complete. Emergency Tow does not use the saved-route cache or
 render the wing walker. Normal pushbacks retain the accepted STOP, STANDBY, and
@@ -81,7 +81,7 @@ Linux and Windows versions are built in one step on an Ubuntu 16.04 (or
 compatible) machine and the Mac version is obviously built on macOS (10.9
 or later).
 
->Note: __on macOS only__ , by using the option ```-f```, the script will build also the linux and windows versions. see ```README-docker.md```.
+>Note: __on macOS only__ , by using the option ```-f```, the script will build also the linux and windows versions. see ```README-docker.md```. Use ```-m``` on a development build to emulate the enlarged macOS Ground Operations layout on Windows or Linux.
 
 For the Linux and Mac build pre-requisites, see ```build_xpl.sh```
 
@@ -97,9 +97,11 @@ by configuring the build with:
 cmake -DBP_ENABLE_LEGACY_MAGIC_SQUARES=ON ...
 ```
 
-This switch controls presentation only. Existing commands, preferences,
-automatic tug-start behavior, the overhead planner, and disconnect/reconnect
-interfaces remain available in either setting.
+This switch controls only the four original shortcut windows. Ground
+Operations remains enabled, and the overhead planner and classic menu commands
+remain available. The end sequence disconnects automatically; the original
+disconnect/reconnect window implementation is retained as dormant source and
+is not created.
 
 The global build script is located here and is called '```build_release```'.
 Once you have the pre-requisite build packages installed, simply run:
@@ -142,8 +144,9 @@ $ ./tests/run_all_tests.sh
 
 BetterPushback registers these X-Plane commands:
 
-- `BetterPushback/start`: Start pushback (or connect-first if configured).
-- `BetterPushback/pause_resume`: Smoothly pause or resume automatic pushback
+- `BetterPushback/start`: Start pushback (or reopen the planner as **Change
+  plan** during the connected parking-brake hold).
+- `BetterPushback/pause_resume`: Pause or resume automatic pushback
   without discarding the accepted route.
 - `BetterPushback/stop`: End pushback and disconnect. This retains the legacy
   command path for compatibility but is presented distinctly from Pause.
@@ -155,9 +158,8 @@ BetterPushback registers these X-Plane commands:
 - `BetterPushback/ground_ops_show_hide`: Show or hide Ground Operations.
 - `BetterPushback/ground_ops_expand_collapse`: Expand or collapse Ground
   Operations.
-- `BetterPushback/disconnect`: Approve physical disconnect when prompted.
-- `BetterPushback/reconnect`: Reconnect during the supported disconnect
-  decision stage.
+- `BetterPushback/disconnect`: Internal compatibility command used by the
+  automatic physical-disconnect sequence.
 - `BetterPushback/cab_camera`: View from the tug cab.
 - `BetterPushback/recreate_scenery_routes`: Recreate scenery routes from WED files.
 - `BetterPushback/preference`: Open the preference window.

--- a/REALISM_NOTES.md
+++ b/REALISM_NOTES.md
@@ -1,6 +1,15 @@
-# Tug physics calibration notes
+# Archived tug-physics experiments
 
-This branch separates four quantities that the original implementation mixed
+> Historical record only. The steering profiles, tail/path corrections,
+> acceleration ramp, jerk limiter, force-cap experiment, corrected tug
+> wheelbase, and controller-matched preview described below are not active in
+> the current build. Owner review restored the upstream legacy planner,
+> `drive_segs` steering, turn/endpoint behavior, tug approach geometry, and
+> breakaway behavior. The only retained motion customization is each tug's
+> configured loaded towing-speed limit. The per-aircraft experimental plugin
+> exclusion was also restored with its original disable/re-enable behavior.
+
+This archive records experiments that separated four quantities the original implementation mixed
 or ignored: unloaded speed, aircraft-carrying speed, acceleration/deceleration,
 and available tractive effort.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -395,7 +395,8 @@ dedicated implementation were removed on 2026-08-05.
 - [ ] No measurable idle FPS regression beyond the documented budget.
 - [ ] No unbounded memory growth.
 - [ ] Every external failure has a tested fallback.
-- [ ] Telemetry contains enough context to reproduce motion defects.
+- [ ] Opt-in diagnostic telemetry contains enough context to reproduce motion
+  defects, while normal builds create no telemetry files.
 
 ## Phase 10 — Release candidate
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,12 +5,34 @@ only after all of its exit gates have evidence. New ideas are added to the
 traceability table before they are scheduled so agreed requirements are not
 lost.
 
-Status date: 2026-08-04
+Status date: 2026-09-04
+
+## Owner-review reconciliation
+
+The 2026-09-04 owner review supersedes older experimental-controller text in
+this roadmap. The release candidate must:
+
+- use upstream's legacy route construction, `drive_segs` steering, turn
+  tracking, planned-route stopping, and tug approach geometry;
+- retain only configured loaded tug speed limits from the physics experiment;
+- pause longitudinal motion without replacing legacy steering, resume the
+  same accepted route, and let **Stop Here** disconnect without a planned-end
+  correction;
+- disconnect automatically and never create the old disconnect/reconnect
+  windows, while keeping their source available;
+- always enable Ground Operations and captions, with the obsolete preference
+  rows removed and the original ACF Plugin Exclusion restored;
+- offer **Change plan** only while connected and held by the parking brake;
+- scale Ground Operations proportionally to 1.35 on macOS, with a matching
+  Windows/Linux development-emulation build for review.
+
+Automated source tests cover the default and emulated platform scales. Final
+visual acceptance still requires the owner's macOS simulator check.
 
 ## Non-negotiable guardrails
 
-1. Preserve the smooth, controller-matched push trajectory already validated in
-   live tests.
+1. Preserve the upstream legacy planner and push trajectory exactly; UI and
+   telemetry must remain observational.
 2. Preserve endpoint accuracy within the tested operational margin.
 3. Do not add frame-rate-bound business logic, networking, parsing, or planner
    simulation.
@@ -33,10 +55,10 @@ Status date: 2026-08-04
 | 3 | State progression, pilot-called connection, and captions | Complete | Phase 2 |
 | 4 | Controlled Pause/Resume and End/Disconnect | Complete | Phase 3 |
 | 5 | Simulator-local flight and weather context | Complete | Phase 3 |
-| 6 | Ground-crew scheduling and communications workflow | Pending | Phases 3, 5 |
-| 7 | Manual planner restoration and route-cache correction | In progress | Phase 1 |
-| 8 | Configurable disconnect and tug-driver presentation | Pending | Phases 3, 6 |
-| 9 | Compatibility, performance, and long-session hardening | Pending | Phases 1-8 |
+| 6 | Ground-crew scheduling and communications workflow | Complete | Phases 3, 5 |
+| 7 | Manual planner and legacy motion restoration | Complete | Phase 1 |
+| 8 | Automatic disconnect and tug-driver presentation | In progress | Phases 3, 6 |
+| 9 | Compatibility, performance, and long-session hardening | In progress | Phases 1-8 |
 | 10 | Release candidate, documentation, and packaging | Pending | Phase 9 |
 
 Detailed UI behavior is defined in `GROUND_OPS_UI_DESIGN.md`.
@@ -59,54 +81,39 @@ Detailed UI behavior is defined in `GROUND_OPS_UI_DESIGN.md`.
 - [x] Full roadmap is tracked in the repository.
 - [x] README links to both documents.
 
-## Phase 1 — Planner caching and performance foundation
+## Phase 1 — Legacy planner caching and performance foundation
 
 ### Problem
 
-The controller-matched planner currently rebuilds its prediction during drawing.
-That work can copy and allocate route segments, simulate many controller steps,
-and terrain-probe every generated point. Draw callbacks can run more than once
-per frame, so this must be eliminated before adding another UI surface.
+The legacy planner must not allocate a replacement cursor route while the
+cursor and accepted route are unchanged. Draw callbacks can run more than once
+per frame, so unchanged geometry is reused without changing its construction.
 
 ### Implementation
 
-- Add a monotonically increasing route revision.
-- Increment the revision when:
-  - a predicted segment changes with the cursor;
-  - predicted segments are committed;
-  - a segment is rotated or deleted;
-  - all segments are cleared;
-  - a route is loaded or restored;
-  - aircraft geometry or controller parameters change;
-  - the planner starts or the local scenery reference changes.
-- Store the last successfully built revision and aircraft-geometry revision.
-- Rebuild the controller path only when one of those revisions changes.
-- Create one terrain probe per rebuild and cache all path heights.
-- Reuse the preallocated controller-path storage and retain route segment
-  allocation only when the cursor solution actually changes.
-- Remove plugin-owned segment allocation from the steady draw path.
-- Draw the cached blue centerline and magenta band without simulation or probes.
-- Cache a bounded failure result so an invalid route does not retry every draw.
-- Add rebuild count, point count, duration, and failure reason to diagnostic
-  logging without logging every frame.
+- Reuse the last legacy `compute_segs` cursor result when its inputs are
+  unchanged.
+- Invalidate that cache on cursor, route, aircraft geometry, or local-reference
+  changes.
+- Draw the legacy segment centerline and clearance band without running a
+  second motion controller.
+- Keep all caching observational: accepted segment coordinates and live
+  `drive_segs` inputs remain upstream-compatible.
 
 ### Tests
 
 - Unit-test invalidation decisions and revision changes.
 - Unit-test that an unchanged route does not rebuild.
-- Compare cached and uncached path endpoints and sampled geometry.
+- Compare cached and uncached legacy segment endpoints.
 - Exercise add, rotate, delete, clear, reopen, and aircraft reload.
-- Test geometric fallback with an intentionally invalid or overlong route.
-- Confirm no terrain probes or segment allocations occur during unchanged
-  planner draws.
+- Confirm no segment allocations occur during unchanged planner draws.
 
 ### Exit gates
 
 - [x] Centerline and danger-zone appearance remain unchanged.
-- [x] Endpoint prediction remains within the validated tolerance.
+- [x] Cached and uncached legacy endpoints match.
 - [x] An unchanged route and cursor produce zero prediction rebuilds during
       repeated draw callbacks.
-- [x] An unchanged route produces zero terrain probes during drawing.
 - [x] Planner open/close and every edit operation remain stable.
 - [x] Automated tests and Windows build pass.
 - [x] Live planner FPS comparison shows no regression.
@@ -127,7 +134,9 @@ per frame, so this must be eliminated before adding another UI surface.
 - Persist floating and operating-system geometry separately.
 - Add show/hide and expand/collapse X-Plane commands and menu entries.
 - Render static placeholders only; do not mutate tug or aircraft state.
-- Add an option to disable the new UI and use classic commands only.
+- Keep Ground Operations enabled while preserving classic menu commands.
+- Apply one proportional 1.35 macOS scale to window geometry, text, and hit
+  targets, plus a development emulation build on Windows/Linux.
 
 ### Tests
 
@@ -164,7 +173,7 @@ per frame, so this must be eliminated before adding another UI surface.
   when the snapshot changes.
 - Drive the five compact-rail nodes from the snapshot.
 - Show the amber action marker only when pilot input is required.
-- Mirror existing crew messages as optional on-screen captions.
+- Mirror existing crew messages as always-enabled on-screen captions.
 - Collapse and restore correctly around the overhead planner.
 - Add bounded transition logging for telemetry and troubleshooting.
 
@@ -300,7 +309,7 @@ per frame, so this must be eliminated before adding another UI surface.
 - [ ] No automatic action occurs earlier than its configured readiness rule.
 - [ ] Door/GPU/ASU and brake mismatches are explained without forcing aircraft
       systems.
-- [ ] Reconnect and abort paths remain valid.
+- [ ] Emergency Tow and abort paths remain valid after automatic disconnect.
 - [x] A completed operation can call an isolated Emergency Tow and return to a
       normal cold-start workflow without changing any gate-route cache file.
 
@@ -315,7 +324,7 @@ dedicated implementation were removed on 2026-08-05.
 - [x] Restore planner startup to the original manual-placement workflow.
 - [x] Remove wind/runway inference, automatic segment seeding, proposal UI text,
       and proposal-specific input handling.
-- [x] Keep the blue controller trajectory and magenta danger band as visual
+- [x] Keep the legacy blue planner route and magenta danger band as visual
       review tools for the pilot-drawn route.
 - [x] Preserve a route explicitly drawn in the current planner session.
 - [x] Keep persistent route loading and saving disabled while its alignment
@@ -352,7 +361,8 @@ dedicated implementation were removed on 2026-08-05.
 - [ ] Driver is visible from representative left-seat cockpit positions.
 - [ ] Tug does not cross the aircraft footprint during repositioning.
 - [ ] Disconnect cannot hang if the preferred presentation route is invalid.
-- [ ] Existing auto-disconnect and reconnect settings remain compatible.
+- [x] Final disconnection is automatic and creates no disconnect/reconnect
+      decision windows.
 
 ## Phase 9 — Hardening and compatibility
 

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -1,11 +1,16 @@
 # Pushback telemetry
 
-This build records each pushback so tug behavior can be measured while the
-motion model is tuned.
+Normal builds do not record pushback telemetry. This prevents routine simulator
+use from accumulating a new CSV file after every operation.
+
+Telemetry remains available for short, controlled diagnostic sessions while
+tug behavior is being investigated. Build with `./build_xpl.sh -t`, or pass
+`-DBP_ENABLE_RUNTIME_TELEMETRY=ON` to CMake, to enable it. Do not use a
+telemetry-enabled binary as a normal distribution build.
 
 ## Output
 
-One CSV file is created per pushback in:
+When explicitly enabled, one CSV file is created per pushback in:
 
 ```text
 <X-Plane folder>\Output\BetterPushback\telemetry

--- a/build_xpl.sh
+++ b/build_xpl.sh
@@ -36,7 +36,7 @@ CMAKE_OPTS_COMMON="-DCMAKE_BUILD_TYPE=Release -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 
 
 
-while getopts "nfmh" o; do
+while getopts "nfmth" o; do
 	case "${o}" in
 	f)
 	if [[ $(uname) = "Darwin" ]]; then
@@ -56,13 +56,17 @@ while getopts "nfmh" o; do
 	m)
 		CMAKE_OPTS_COMMON="$CMAKE_OPTS_COMMON -DBP_EMULATE_MAC_UI_SCALE=ON"
 		;;
+	t)
+		CMAKE_OPTS_COMMON="$CMAKE_OPTS_COMMON -DBP_ENABLE_RUNTIME_TELEMETRY=ON"
+		;;
 	h)
 		cat << EOF
-Usage: $0 [-fmnh]
+Usage: $0 [-fmtnh]
 	-f : (macOS-only) Cross-compile to linux and window
 		using the docker image provided by docker-compose.yml.
 		See README-docker.md for more information.
     -m : development build using the macOS Ground Operations scale
+    -t : development build recording per-pushback telemetry CSV files
     -n : (macOS-only) Codesign & notarize the resulting XPL after build
          Note: requires that you create a file named user.make in the
          notarize directory with DEVELOPER_USERNAME and DEVELOPER_PASSWORD

--- a/build_xpl.sh
+++ b/build_xpl.sh
@@ -36,7 +36,7 @@ CMAKE_OPTS_COMMON="-DCMAKE_BUILD_TYPE=Release -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 
 
 
-while getopts "nfh" o; do
+while getopts "nfmh" o; do
 	case "${o}" in
 	f)
 	if [[ $(uname) = "Darwin" ]]; then
@@ -53,12 +53,16 @@ while getopts "nfh" o; do
 		fi
 		notarize=1
 		;;
+	m)
+		CMAKE_OPTS_COMMON="$CMAKE_OPTS_COMMON -DBP_EMULATE_MAC_UI_SCALE=ON"
+		;;
 	h)
 		cat << EOF
-Usage: $0 [-fnh]
+Usage: $0 [-fmnh]
 	-f : (macOS-only) Cross-compile to linux and window
 		using the docker image provided by docker-compose.yml.
 		See README-docker.md for more information.
+    -m : development build using the macOS Ground Operations scale
     -n : (macOS-only) Codesign & notarize the resulting XPL after build
          Note: requires that you create a file named user.make in the
          notarize directory with DEVELOPER_USERNAME and DEVELOPER_PASSWORD

--- a/objects/tugs/AP88.tug/info.cfg
+++ b/objects/tugs/AP88.tug/info.cfg
@@ -28,8 +28,6 @@ electric_drive
 mass		4400		# tug mass, kg
 max_TE		65000		# maximum tractive effort, Newtons
 max_steer	60		# maximum steering angle, degrees
-max_fwd_speed	4.0278		# 14.5 km/h unloaded safe speed
-max_rev_speed	4.0278		# AP88 manual gives no directional split
 max_tow_fwd_speed 1.7778	# 6.4 km/h fully loaded safe speed
 max_tow_rev_speed 1.7778	# 6.4 km/h fully loaded safe speed
 front_z		0.77		# front axle long displacement, meters

--- a/objects/tugs/AST-1X.tug/info.cfg
+++ b/objects/tugs/AST-1X.tug/info.cfg
@@ -24,9 +24,8 @@
 tug_obj		AST-1X.obj	# main tug object
 
 mass		35000		# tug mass, kg
-max_TE		212000		# manufacturer tractive force, Newtons
+max_TE		230000		# maximum tractive effort, Newtons
 max_steer	60		# maximum steering angle, degrees
-max_fwd_speed	8.8889		# manufacturer maximum: 32 km/h
 front_z		1.82		# front axle long displacement, meters
 front_r		0.69		# front wheel radius, meters
 rear_z		-2.57		# rear axle long displacement, meters

--- a/objects/tugs/AST-3F.tug/info.cfg
+++ b/objects/tugs/AST-3F.tug/info.cfg
@@ -26,7 +26,6 @@ tug_obj			AST-3F.obj	# main tug object
 mass			13000		# tug mass, kg
 max_TE			480000		# maximum tractive effort, Newtons
 max_steer		60		# maximum steering angle, degrees
-max_fwd_speed		8.8889		# published maximum: 32 km/h
 front_z			0.09		# front axle long displacement, meters
 front_r			0.375		# front wheel radius, meters
 rear_z			-2.9		# rear axle long displacement, meters

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,6 +28,14 @@ else()
     add_compile_definitions(BP_ENABLE_LEGACY_MAGIC_SQUARES=0)
 endif()
 
+option(BP_EMULATE_MAC_UI_SCALE
+    "Use the macOS Ground Operations scale on a development build" OFF)
+if(BP_EMULATE_MAC_UI_SCALE)
+    add_compile_definitions(BP_EMULATE_MAC_UI_SCALE=1)
+else()
+    add_compile_definitions(BP_EMULATE_MAC_UI_SCALE=0)
+endif()
+
 if (NOT DEFINED COPYRIGHT_YEAR)
     string(TIMESTAMP COPYRIGHT_YEAR "%Y")
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,6 +36,14 @@ else()
     add_compile_definitions(BP_EMULATE_MAC_UI_SCALE=0)
 endif()
 
+option(BP_ENABLE_RUNTIME_TELEMETRY
+    "Record per-pushback diagnostic CSV files at runtime" OFF)
+if(BP_ENABLE_RUNTIME_TELEMETRY)
+    add_compile_definitions(BP_ENABLE_RUNTIME_TELEMETRY=1)
+else()
+    add_compile_definitions(BP_ENABLE_RUNTIME_TELEMETRY=0)
+endif()
+
 if (NOT DEFINED COPYRIGHT_YEAR)
     string(TIMESTAMP COPYRIGHT_YEAR "%Y")
 endif()

--- a/src/bp.c
+++ b/src/bp.c
@@ -61,7 +61,6 @@
 #include "cfg.h"
 #include "emergency_tow.h"
 #include "msg.h"
-#include "realism_config.h"
 #include "telemetry.h"
 #include "xplane.h"
 
@@ -118,6 +117,9 @@
  */
 #define    TOW_COMPLETE_TUG_STEER_THRESH    5    /* degrees */
 #define    TOW_COMPLETE_ACF_STEER_THRESH    2.5    /* degrees */
+
+/* Begin neutralizing the final straight at the upstream legacy threshold. */
+#define    NEARING_END_THRESHOLD        1    /* meters */
 
 enum {
     RWY_FRICTION_GOOD = 0,
@@ -185,8 +187,6 @@ bp_long_state_t bp_ls = {0};
 
 static bool_t inited = B_FALSE;
 static XPLMFlightLoopID bp_floop = NULL;
-
-static bool_t cfg_disco_when_done = B_FALSE;
 
 static bool_t cfg_ignore_park_break = B_FALSE;
 
@@ -258,8 +258,6 @@ void main_intf_hide(void);
 
 static int disco_handler(XPLMCommandRef, XPLMCommandPhase, void *);
 
-static int recon_handler(XPLMCommandRef, XPLMCommandPhase, void *);
-
 static bool_t bp_run_push_manual(void);
 
 void acf_plg_debut(void);
@@ -300,12 +298,15 @@ static const char *const bp_step_names[] = {
     "driving_away"
 };
 
-static XPLMCommandRef disco_cmd = NULL, recon_cmd = NULL;
+static XPLMCommandRef disco_cmd = NULL;
+#if 0
+static XPLMCommandRef recon_cmd = NULL;
 static button_t disco_buttons[] = {
         {.filename = "disconnect.png", .vk = -1, .tex = 0, .tex_data = NULL},
         {.filename = "reconnect.png", .vk = -1, .tex = 0, .tex_data = NULL},
         {.filename = NULL},
 };
+#endif
 
 static button_t magic_buttons[] = {
         {.filename = "planner.png", .vk = -1, .tex = 0, .tex_data = NULL, .wind_id = NULL},
@@ -314,6 +315,13 @@ static button_t magic_buttons[] = {
         {.filename = "status.png", .vk = -1, .tex = 0, .tex_data = NULL, .wind_id = NULL},
         {.filename = NULL},
 };
+
+static struct
+{
+    int exclusion_started;
+    int plg_status;
+    XPLMPluginID plg_id;
+} acf_tracker_plg_exclude = {0, 0, -1};
 
 /*
  * This flag is set by the planner if the user clicked on the "connect first"
@@ -472,6 +480,14 @@ bp_pause_is_held(void)
 }
 
 bool_t
+bp_can_replan(void)
+{
+    return (bp_started && !slave_mode && !push_manual.active &&
+        bp.step == PB_STEP_CONNECTED && pbrake_is_set() &&
+        list_head(&bp.segs) != NULL && !bp_cam_is_running());
+}
+
+bool_t
 bp_is_awaiting_plan(void)
 {
     return (bp_started && bp.awaiting_plan);
@@ -500,29 +516,6 @@ telemetry_sanitize_name(const char *input, char *output, size_t capacity)
     } else {
         output[j] = '\0';
     }
-}
-
-/* Distance from the main-gear reference point to the aft outline point. */
-static double
-aircraft_tail_arm(void)
-{
-    double aft_y = -HUGE_VAL;
-
-    if (bp_ls.outline != NULL) {
-        for (size_t i = 0; i < bp_ls.outline->num_pts; i++) {
-            vect2_t point = bp_ls.outline->pts[i];
-
-            if (!IS_NULL_VECT(point) && isfinite(point.y))
-                aft_y = MAX(aft_y, point.y);
-        }
-        if (isfinite(aft_y) && aft_y > bp.acf.main_z)
-            return (aft_y - bp.acf.main_z);
-        if (bp_ls.outline->length > 0)
-            return (MAX(bp_ls.outline->length * 0.4,
-                bp.veh.wheelbase / 2));
-    }
-
-    return (MAX(bp.veh.wheelbase, 1));
 }
 
 static void
@@ -602,17 +595,17 @@ telemetry_start(void)
     metadata.aircraft_mass_kg = dr_getf(&drs.acf_mass);
     metadata.aircraft_mtow_kg = dr_getf(&drs.mtow);
     metadata.aircraft_wheelbase_m = bp.veh.wheelbase;
-    metadata.aircraft_tail_arm_m = aircraft_tail_arm();
+    metadata.aircraft_tail_arm_m = NAN;
     metadata.aircraft_max_steer_deg = bp.veh.max_steer;
     metadata.effective_max_fwd_speed_mps = bp.veh.max_fwd_spd;
     metadata.effective_max_rev_speed_mps = bp.veh.max_rev_spd;
-    metadata.push_start_accel_ramp_time_s = PUSH_START_ACCEL_RAMP_TIME;
-    metadata.push_start_jerk_limit_mps3 = PUSH_START_JERK_LIMIT;
-    metadata.turn_profile_transition_m = TURN_PROFILE_TRANSITION_DIST;
-    metadata.turn_profile_steer_rate_dps = TURN_PROFILE_STEER_RATE;
-    metadata.route_path_deadband_deg = ROUTE_PATH_STEER_DEADBAND;
-    metadata.route_path_max_correction_deg = ROUTE_PATH_MAX_CORRECTION;
-    metadata.route_path_terminal_fade_m = ROUTE_PATH_TERMINAL_FADE_DIST;
+    metadata.push_start_accel_ramp_time_s = NAN;
+    metadata.push_start_jerk_limit_mps3 = NAN;
+    metadata.turn_profile_transition_m = NAN;
+    metadata.turn_profile_steer_rate_dps = NAN;
+    metadata.route_path_deadband_deg = NAN;
+    metadata.route_path_max_correction_deg = NAN;
+    metadata.route_path_terminal_fade_m = NAN;
     metadata.tug_mass_kg = bp_ls.tug->info->mass;
     metadata.tug_wheelbase_m = bp_ls.tug->veh.wheelbase;
     metadata.tug_max_steer_deg = bp_ls.tug->veh.max_steer;
@@ -1775,8 +1768,10 @@ void
 bp_boot_init(void) {
     disco_cmd = XPLMCreateCommand("BetterPushback/disconnect",
                                   _("Disconnect tow + headset and switch to hand signals."));
+#if 0
     recon_cmd = XPLMCreateCommand("BetterPushback/reconnect",
                                   _("Reconnect tow and await further instructions."));
+#endif
 
     DCR_CREATE_F(NULL, &bp.anim.nosewheel_rot_spd, false, "bp/anim/nosewheel_rotation_speed_rad_sec");
 }
@@ -1951,7 +1946,6 @@ bp_init(void) {
     fdr_find(&drs.joystick, "sim/joystick/joy_mapped_axis_value");
 
     XPLMRegisterCommandHandler(disco_cmd, disco_handler, 1, NULL);
-    XPLMRegisterCommandHandler(recon_cmd, recon_handler, 1, NULL);
 
     /*
      * We do this check before attempting to read gear info, because
@@ -1963,15 +1957,10 @@ bp_init(void) {
 
     if (!bp_state_init())
         goto errout;
-    if (!audio_sys_init() || !load_buttons() ||
-        !load_icon(&disco_buttons[0]) || !load_icon(&disco_buttons[1]))
+    if (!audio_sys_init() || !load_buttons())
         goto errout;
 
     XPLMGetNthAircraftModel(0, my_acf, my_path);
-
-    cfg_disco_when_done = B_FALSE;
-    conf_get_b_per_acf("disco_when_done", &cfg_disco_when_done);
-
 
     cfg_ignore_park_break = B_FALSE;
     conf_get_b_per_acf("ignore_park_brake", &cfg_ignore_park_break);
@@ -1999,11 +1988,8 @@ bp_init(void) {
     return (B_TRUE);
     errout:
     XPLMUnregisterCommandHandler(disco_cmd, disco_handler, 1, NULL);
-    XPLMUnregisterCommandHandler(recon_cmd, recon_handler, 1, NULL);
     msg_fini();
     unload_buttons();
-    unload_icon(&disco_buttons[0]);
-    unload_icon(&disco_buttons[1]);
     if (bp_ls.outline != NULL) {
         acf_outline_free(bp_ls.outline);
         bp_ls.outline = NULL;
@@ -2207,7 +2193,6 @@ bp_fini(void) {
     }
 
     XPLMUnregisterCommandHandler(disco_cmd, disco_handler, 1, NULL);
-    XPLMUnregisterCommandHandler(recon_cmd, recon_handler, 1, NULL);
 
     msg_fini();
     bp_complete();
@@ -2215,8 +2200,6 @@ bp_fini(void) {
     /* segs have been released in bp_complete */
     list_destroy(&bp.segs);
 
-    unload_icon(&disco_buttons[0]);
-    unload_icon(&disco_buttons[1]);
     unload_buttons();
 
     radio_volume_warn = B_FALSE;
@@ -3057,6 +3040,8 @@ pb_step_lift(void) {
 static void
 pb_step_connected(void) {
     seg_t *seg = NULL;
+    bool_t parking_brake_set = pbrake_is_set();
+
     if ( !push_manual.active ) {
         seg = list_head(&bp.segs);
         if  ( seg == NULL ) {
@@ -3064,7 +3049,12 @@ pb_step_connected(void) {
             return;
         }
     }
-    if (pbrake_is_set() ||
+    if (parking_brake_set)
+        enable_replanning();
+    else
+        disable_replanning();
+
+    if (parking_brake_set ||
         bp.cur_t - bp.last_voice_t < msg_dur(MSG_CONNECTED)) {
         /*
          * Keep resetting the start time to enforce the state delay
@@ -3072,9 +3062,7 @@ pb_step_connected(void) {
          */
         bp.step_start_t = bp.cur_t;
         bp_hint_status_str = _("Waiting for the parking brakes release");
-        enable_replanning();
     } else if (bp.cur_t - bp.step_start_t >= STATE_TRANS_DELAY) {
-        disable_replanning();
         if (!slave_mode) {
             bool_t backward = true; 
             if (!push_manual.active) {
@@ -3426,6 +3414,12 @@ pb_step_closing_cradle(void) {
     }
 }
 
+/*
+ * The original disconnect/reconnect windows are kept here for reference, but
+ * the standard workflow below disconnects automatically and never creates
+ * either window.
+ */
+#if 0
 static void
 disco_win_draw(XPLMWindowID inWindowID, void *inRefcon) {
     int w, h, mx, my;
@@ -3455,6 +3449,7 @@ disco_win_draw(XPLMWindowID inWindowID, void *inRefcon) {
                   B_FALSE, is_lit);
     }
 }
+#endif
 
 static int
 disco_handler(XPLMCommandRef cmd, XPLMCommandPhase phase, void *refcon) {
@@ -3469,6 +3464,7 @@ disco_handler(XPLMCommandRef cmd, XPLMCommandPhase phase, void *refcon) {
     return (1);
 }
 
+#if 0
 static int
 recon_handler(XPLMCommandRef cmd, XPLMCommandPhase phase, void *refcon) {
     UNUSED(cmd);
@@ -3508,6 +3504,7 @@ disco_win_click(XPLMWindowID inWindowID, int x, int y, XPLMMouseStatus inMouse,
 
     return (1);
 }
+#endif
 
 static XPLMCursorStatus
 nil_win_cursor(XPLMWindowID inWindowID, int x, int y, void *inRefcon) {
@@ -3530,6 +3527,7 @@ nil_win_wheel(XPLMWindowID inWindowID, int x, int y, int wheel, int clicks,
     return (1);
 }
 
+#if 0
 static void
 disco_intf_show(void) {
     XPLMCreateWindow_t disco_ops = {
@@ -3564,6 +3562,7 @@ disco_intf_show(void) {
     ASSERT(bp_ls.recon_win != NULL);
     XPLMBringWindowToFront(bp_ls.recon_win);
 }
+#endif
 
 static void
 disco_intf_hide(void) {
@@ -3868,24 +3867,17 @@ main_intf(bool_t force_hide) {
 static void
 pb_step_waiting4ok2disco(void) {
     if (!bp.ok2disco) {
-        if (bp_ls.disco_win == NULL && !slave_mode) {
-            if (cfg_disco_when_done) {
-                /*
-                 * Don't actually show the interface, just
-                 * fire the disconnection command.
-                 */
-                XPLMCommandOnce(disco_cmd);
-                return;
-            }
-            disco_intf_show();
+        if (!slave_mode) {
+            XPLMCommandOnce(disco_cmd);
+            return;
         }
 
-        /* Keep resetting the start time to enforce the delay */
+        /* Wait for the master to advance the shared operation state. */
         bp.step_start_t = bp.cur_t;
         return;
     }
 
-    /* Once the user clicked disconnect, hide the buttons immediately */
+    /* Be defensive if upgrading while an old interface is still visible. */
     disco_intf_hide();
 
     if (bp.cur_t - bp.step_start_t >= STATE_TRANS_DELAY) {
@@ -4364,7 +4356,7 @@ bp_run(float elapsed, float elapsed2, int counter, void *refcon) {
             pb_step_ungrabbing();
             break;
         case PB_STEP_WAITING4OK2DISCO:
-            bp_hint_status_str = _("Waiting the OK to disconnect");
+            bp_hint_status_str = _("Disconnecting the tug");
             pb_step_waiting4ok2disco();
             break;
         case PB_STEP_MOVING_AWAY:
@@ -4463,24 +4455,54 @@ bp_num_segs(void) {
 
 void acf_plg_debut(void)
 {
-    const char *plg_to_exclude = NULL;
+    if (!acf_tracker_plg_exclude.exclusion_started) {
+        const char *plg_to_exclude = NULL;
 
-    /*
-     * Aircraft-local plugins commonly own the electrical, hydraulic, landing
-     * gear and flight-control state. Disabling one while the tug is moving can
-     * therefore depower the aircraft, retract its gear or corrupt its systems
-     * state. Older versions offered this as an experimental per-aircraft
-     * option. Keep reading the setting so stale configurations produce a clear
-     * diagnostic, but never act on it.
-     */
-    if (conf_get_str_per_acf((char *)"plg_acf_to_exclude",
-        (char **)&plg_to_exclude)) {
-        logMsg(BP_WARN_LOG "Ignoring unsafe aircraft plugin exclusion: %s",
-            plg_to_exclude);
+        acf_tracker_plg_exclude.exclusion_started = 1;
+        acf_tracker_plg_exclude.plg_id = -1;
+        if (conf_get_str_per_acf((char *)"plg_acf_to_exclude",
+            (char **)&plg_to_exclude)) {
+            acf_tracker_plg_exclude.plg_id =
+                XPLMFindPluginBySignature(plg_to_exclude);
+        } else {
+            logMsg(BP_INFO_LOG "Acf XPLMDisablePlugin not done, no Acf "
+                "plugin to exclude selected");
+            return;
+        }
+
+        if (acf_tracker_plg_exclude.plg_id != -1) {
+            acf_tracker_plg_exclude.plg_status = XPLMIsPluginEnabled(
+                acf_tracker_plg_exclude.plg_id);
+            if (acf_tracker_plg_exclude.plg_status) {
+                XPLMDisablePlugin(acf_tracker_plg_exclude.plg_id);
+                logMsg(BP_INFO_LOG "Acf XPLMDisablePlugin on %s",
+                    plg_to_exclude);
+            } else {
+                logMsg(BP_INFO_LOG "Acf XPLMDisablePlugin not done, was "
+                    "already disabled");
+            }
+        } else {
+            logMsg(BP_INFO_LOG "Acf XPLMDisablePlugin not done, plugin %s "
+                "not found", plg_to_exclude);
+        }
     }
 }
 
 void acf_plg_fini(void)
 {
-    /* Aircraft plugins are never disabled by acf_plg_debut(). */
+    if (!acf_tracker_plg_exclude.exclusion_started)
+        return;
+
+    if (acf_tracker_plg_exclude.plg_id != -1) {
+        acf_tracker_plg_exclude.plg_status = XPLMIsPluginEnabled(
+            acf_tracker_plg_exclude.plg_id);
+        if (!acf_tracker_plg_exclude.plg_status) {
+            int r = XPLMEnablePlugin(acf_tracker_plg_exclude.plg_id);
+            logMsg(BP_INFO_LOG "Acf XPLMEnablePlugin %d", r);
+        } else {
+            logMsg(BP_INFO_LOG "Acf XPLMEnablePlugin not done, was already "
+                "enabled");
+        }
+    }
+    acf_tracker_plg_exclude.exclusion_started = 0;
 }

--- a/src/bp.c
+++ b/src/bp.c
@@ -60,6 +60,7 @@
 #include "bp_cam.h"
 #include "cfg.h"
 #include "emergency_tow.h"
+#include "ground_ops_ui.h"
 #include "msg.h"
 #include "telemetry.h"
 #include "xplane.h"
@@ -3841,6 +3842,13 @@ main_intf_hide(void) {
 
 void
 main_intf(bool_t force_hide) {
+    /*
+     * Preserve the owner's legacy visibility gate for the replacement Ground
+     * Operations panel: remain visible for an active operation, otherwise
+     * require an airliner on the ground moving at less than 1 m/s.
+     */
+    ground_ops_ui_set_legacy_visibility(bp_started ||
+        (acf_is_airliner() && acf_on_gnd_stopped(NULL)));
     main_intf_update_automation();
 
     /*

--- a/src/bp.c
+++ b/src/bp.c
@@ -522,6 +522,12 @@ telemetry_sanitize_name(const char *input, char *output, size_t capacity)
 static void
 telemetry_start(void)
 {
+    bp_telemetry_close(&bp_telem.writer);
+    telemetry_begin_frame();
+
+    if (!BP_ENABLE_RUNTIME_TELEMETRY)
+        return;
+
     char aircraft_file[512] = {0}, aircraft_path[512] = {0};
     char aircraft_icao[16] = {0}, tug_name[128] = {0};
     char timestamp[32] = {0}, filename[256];
@@ -531,9 +537,6 @@ telemetry_start(void)
     dr_t icao_dr;
     time_t wall_time;
     struct tm *local_time;
-
-    bp_telemetry_close(&bp_telem.writer);
-    telemetry_begin_frame();
 
     directory = mkpathname(bp_xpdir, "Output", "BetterPushback",
         "telemetry", NULL);
@@ -633,6 +636,9 @@ telemetry_start(void)
 static void
 telemetry_record(bool_t force)
 {
+    if (!BP_ENABLE_RUNTIME_TELEMETRY || bp_telem.writer.fp == NULL)
+        return;
+
     bp_telemetry_sample_t sample = {
         .segment_backward = -1,
         .segment_end_distance_m = NAN,
@@ -668,9 +674,6 @@ telemetry_record(bool_t force)
     };
     seg_t *segment;
     double nosewheel_steer = NAN;
-
-    if (bp_telem.writer.fp == NULL)
-        return;
 
     segment = list_head(&bp.segs);
     sample.sim_time_s = bp.cur_t;

--- a/src/bp.c
+++ b/src/bp.c
@@ -63,7 +63,6 @@
 #include "msg.h"
 #include "realism_config.h"
 #include "telemetry.h"
-#include "vehicle_physics.h"
 #include "xplane.h"
 
 #ifndef BP_ENABLE_LEGACY_MAGIC_SQUARES
@@ -249,6 +248,8 @@ static void tug_pos_update(vect2_t my_pos, double my_hdg, bool_t pos_only);
 
 static double aircraft_nose_forward_offset(void);
 
+static double route_distance_remaining(void);
+
 static void disco_intf_hide(void);
 
 static void main_intf_show(void);
@@ -417,12 +418,13 @@ bp_get_ground_ops_metrics(double *speed_mps, bool_t *speed_valid,
         *speed_mps = fabs(bp.cur_pos.spd);
     if (speed_valid != NULL)
         *speed_valid = isfinite(bp.cur_pos.spd) ? B_TRUE : B_FALSE;
-    if (bp.step == PB_STEP_PUSHING &&
-        isfinite(bp_telem.tail_along_remaining_m)) {
+    if (bp.step == PB_STEP_PUSHING && list_head(&bp.segs) != NULL) {
+        double remaining = route_distance_remaining();
+
         if (distance_remaining_m != NULL) {
-            *distance_remaining_m = MAX(bp_telem.tail_along_remaining_m, 0);
+            *distance_remaining_m = MAX(remaining, 0);
         }
-        if (distance_valid != NULL)
+        if (distance_valid != NULL && isfinite(remaining))
             *distance_valid = B_TRUE;
     }
 }
@@ -437,7 +439,6 @@ bp_request_pause(void)
 
     bp.pause_requested = B_TRUE;
     bp.pause_hold = B_FALSE;
-    bp.push_accel_limit = 0;
     logMsg(BP_INFO_LOG "Automatic push pause requested; preserving route");
     return (B_TRUE);
 }
@@ -453,7 +454,6 @@ bp_request_resume(void)
 
     bp.pause_requested = B_FALSE;
     bp.pause_hold = B_FALSE;
-    bp.push_accel_limit = 0;
     logMsg(BP_INFO_LOG "Automatic push resume requested; continuing route");
     return (B_TRUE);
 }
@@ -709,8 +709,9 @@ telemetry_record(bool_t force)
         sample.tug_heading_deg = bp_ls.tug->pos.hdg;
         sample.tug_speed_mps = bp_ls.tug->pos.spd;
         sample.tug_steer_deg = bp_ls.tug->cur_steer;
-        sample.tug_turn_radius_m = vehicle_turn_radius(
-            bp_ls.tug->veh.wheelbase, bp_ls.tug->cur_steer);
+        sample.tug_turn_radius_m =
+            tan(DEG2RAD(90 - bp_ls.tug->cur_steer)) *
+            bp_ls.tug->veh.wheelbase;
         sample.tug_aircraft_heading_delta_deg = rel_hdg(bp.cur_pos.hdg,
             bp_ls.tug->pos.hdg);
         dr_getvf(&drs.tire_steer_cmd, &nosewheel_steer, bp.acf.nw_i, 1);
@@ -1308,8 +1309,8 @@ turn_nosewheel(double req_steer) {
     bp_telem.nosewheel_steer_request_deg = req_steer;
 
     if (ABS(bp_ls.tug->cur_steer) > 0.01) {
-        tug_turn_r = vehicle_turn_radius(bp_ls.tug->veh.wheelbase,
-            bp_ls.tug->cur_steer);
+        tug_turn_r = (1 / tan(DEG2RAD(bp_ls.tug->cur_steer))) *
+                     bp_ls.tug->veh.wheelbase;
     } else {
         tug_turn_r = 1e10;
     }
@@ -1422,9 +1423,7 @@ push_at_speed(double targ_speed, double max_accel, bool_t allow_snd_ctl,
      * flinging the aircraft across the tarmac in case some external
      * factor is blocking us (like chocks).
      */
-    force_lim = vehicle_force_limit(
-        FORCE_PER_TON * (dr_getf(&drs.acf_mass) / 1000),
-        bp_ls.tug->info->max_TE);
+    force_lim = FORCE_PER_TON * (dr_getf(&drs.acf_mass) / 1000);
     bp_telem.command_active = B_TRUE;
     bp_telem.target_speed_raw_mps = raw_targ_speed;
     bp_telem.target_speed_limited_mps = targ_speed;
@@ -1459,6 +1458,14 @@ push_at_speed(double targ_speed, double max_accel, bool_t allow_snd_ctl,
     force = bp.last_force;
     d_v = targ_speed - cur_spd;
 
+    /*
+     * This is some fudge needed to get some high-thrust aircraft
+     * going, otherwise we'll just jitter in-place due to thinking
+     * we're overdoing acceleration.
+     */
+    if (ABS(cur_spd) < BREAKAWAY_THRESH)
+        max_accel *= 100;
+
     if (d_v > 0) {        /* speed up */
         /*
          * Modulate the acceleration to reach our target speed smoothly,
@@ -1482,10 +1489,6 @@ push_at_speed(double targ_speed, double max_accel, bool_t allow_snd_ctl,
         else if (accel_now > max_accel)
             force -= force_incr;
     }
-
-    /* Clamp before applying the force to X-Plane. */
-    force = MIN(force_lim, force);
-    force = MAX(-force_lim, force);
 
     /*
      * Calculate the vector components of our force on the aircraft
@@ -1540,9 +1543,10 @@ push_at_speed(double targ_speed, double max_accel, bool_t allow_snd_ctl,
     }
     dr_setf(&drs.rot_force_M, nose_down_moment);
 
-    /* The nose-gear safety correction above must not escape the limit. */
+    /* Don't overstep the force limits for this aircraft */
     force = MIN(force_lim, force);
     force = MAX(-force_lim, force);
+
     bp.last_force = force;
 
     if (allow_snd_ctl) {
@@ -2175,7 +2179,6 @@ bp_stop(void) {
     }
     bp.pause_requested = B_FALSE;
     bp.pause_hold = B_FALSE;
-    bp.push_accel_limit = 0;
 
     /* prevent trying to reach segment end hdg and apply correct back */
     bp.last_hdg = NAN;
@@ -2221,6 +2224,23 @@ bp_fini(void) {
     inited = B_FALSE;
 }
 
+static bool_t
+nearing_end(void) {
+    double long_displ;
+    seg_t *seg = list_head(&bp.segs);
+    vect2_t end_dir, end2acf;
+
+    if (seg->type != SEG_TYPE_STRAIGHT || seg != list_tail(&bp.segs))
+        return (B_FALSE);
+
+    end_dir = hdg2dir(seg->end_hdg);
+    if (seg->backward)
+        end_dir = vect2_neg(end_dir);
+    end2acf = vect2_sub(bp.cur_pos.pos, seg->end_pos);
+    long_displ = vect2_dotprod(end_dir, end2acf);
+    return (long_displ > -NEARING_END_THRESHOLD);
+}
+
 /*
  * We need to compute a fake position for drive_segs. This is because when
  * steering, we don't actually perform simple steering around our nosewheel.
@@ -2248,6 +2268,50 @@ corr_acf_pos(void) {
     corr_hdg = dir2hdg(corr_dir);
 
     return ((vehicle_pos_t) {corr_pos, corr_hdg, bp.cur_pos.spd});
+}
+
+/*
+ * Read-only route distance for the Ground Operations display. This mirrors
+ * the legacy drive_segs distance inputs and never feeds back into steering,
+ * speed control or segment completion.
+ */
+static double
+route_distance_remaining(void)
+{
+    const seg_t *seg = list_head(&bp.segs);
+    vehicle_pos_t pos;
+    double remaining = 0;
+
+    if (seg == NULL)
+        return (NAN);
+
+    pos = corr_acf_pos();
+    if (seg->type == SEG_TYPE_STRAIGHT) {
+        vect2_t fixed_pos = vect2_add(pos.pos,
+            vect2_scmul(hdg2dir(pos.hdg), bp.veh.fixed_z_off));
+        vect2_t dir = seg->backward ?
+            vect2_neg(hdg2dir(seg->start_hdg)) :
+            hdg2dir(seg->start_hdg);
+        double travelled = vect2_dotprod(
+            vect2_sub(fixed_pos, seg->start_pos), dir);
+
+        remaining = MAX(seg->len - travelled, 0);
+    } else {
+        remaining = DEG2RAD(fabs(rel_hdg(pos.hdg, seg->end_hdg))) *
+            seg->turn.r;
+    }
+
+    for (seg = list_next(&bp.segs, seg); seg != NULL;
+        seg = list_next(&bp.segs, seg)) {
+        if (seg->type == SEG_TYPE_STRAIGHT) {
+            remaining += seg->len;
+        } else {
+            remaining += DEG2RAD(fabs(rel_hdg(seg->start_hdg,
+                seg->end_hdg))) * seg->turn.r;
+        }
+    }
+
+    return (remaining);
 }
 
 /*
@@ -2297,140 +2361,6 @@ telemetry_route_tracking(const seg_t *seg, const vehicle_pos_t *corr_pos)
     bp_telem.route_heading_error_deg = rel_hdg(corr_pos->hdg, route_hdg);
 }
 
-static const seg_t *
-tail_control_target_segment(const seg_t *current)
-{
-    const seg_t *target = current;
-
-    if (current->type == SEG_TYPE_STRAIGHT)
-        return (current);
-
-    for (const seg_t *candidate = current; candidate != NULL;
-        candidate = list_next(&bp.segs, candidate)) {
-        target = candidate;
-        if (candidate->user_placed)
-            break;
-    }
-    return (target);
-}
-
-static double
-control_deadband(double value, double deadband)
-{
-    if (fabs(value) <= deadband)
-        return (0);
-    return (value - copysign(deadband, value));
-}
-
-static double
-capture_weight(double fraction)
-{
-    fraction = MIN(MAX(fraction, 0), 1);
-    return (fraction * fraction * fraction *
-        (fraction * (fraction * 6 - 15) + 10));
-}
-
-/*
- * Smooth feed-forward curvature keeps the tug motion natural. Tail and
- * heading feedback close the loop against the exact pose selected in the
- * planner. On a straight, the tail follows that segment's centerline. In a
- * turn, feedback progressively captures the next user-placed aircraft pose,
- * mirroring a tug driver holding the nose angle and watching the tail swing.
- */
-static double
-automatic_steer_target(const seg_t *seg, double route_steer)
-{
-    const seg_t *control_target = tail_control_target_segment(seg);
-    double signed_turn = 0, total_distance = 0, direction = 0;
-    double profile_target = 0, capture_fraction = 1, feedback, target;
-    double path_correction, path_weight;
-    double tail_arm = aircraft_tail_arm();
-    double cross_track, heading_error, along_remaining;
-    vect2_t aircraft_dir = hdg2dir(bp.cur_pos.hdg);
-    vect2_t target_dir = hdg2dir(control_target->end_hdg);
-    vect2_t target_right = vect2_norm(target_dir, B_TRUE);
-    vect2_t travel_dir = (control_target->backward ?
-        vect2_neg(target_dir) : target_dir);
-    vect2_t main_pos = vect2_add(bp.cur_pos.pos,
-        vect2_scmul(aircraft_dir, -bp.acf.main_z));
-    vect2_t tail_pos = vect2_add(main_pos,
-        vect2_scmul(aircraft_dir, -tail_arm));
-    vect2_t target_tail_pos = vect2_add(control_target->end_pos,
-        vect2_scmul(target_dir, -tail_arm));
-
-    if (seg->type == SEG_TYPE_TURN) {
-        signed_turn = rel_hdg(seg->start_hdg, seg->end_hdg);
-        total_distance = DEG2RAD(fabs(signed_turn)) * seg->turn.r;
-        if (!bp.turn_profile_active ||
-            fabs(rel_hdg(bp.turn_profile_end_hdg, seg->end_hdg)) > 1e-6) {
-            bp.turn_profile_active = B_TRUE;
-            bp.turn_profile_distance = 0;
-            bp.turn_profile_end_hdg = seg->end_hdg;
-        }
-
-        bp.turn_profile_distance = MIN(bp.turn_profile_distance +
-            fabs(bp.cur_pos.spd) * bp.d_t, total_distance);
-        direction = (signed_turn >= 0 ? 1 : -1) *
-            (seg->backward ? -1 : 1);
-        profile_target = vehicle_turn_profile_steer(bp.veh.wheelbase,
-            seg->turn.r, total_distance, bp.turn_profile_distance,
-            TURN_PROFILE_TRANSITION_DIST, direction, bp.veh.max_steer);
-        /*
-         * Hold the planned turn through its first half. Start watching the
-         * terminal tail line during the second half, just as a driver waits
-         * for the tail to swing before deciding when to unwind.
-         */
-        capture_fraction = (total_distance > 0 ?
-            2 * (bp.turn_profile_distance / total_distance - 0.5) : 1);
-        capture_fraction = MIN(MAX(capture_fraction, 0), 1);
-
-        bp_telem.turn_profile_progress_m = bp.turn_profile_distance;
-        bp_telem.turn_profile_total_m = total_distance;
-    } else {
-        bp.turn_profile_active = B_FALSE;
-        bp.turn_profile_distance = 0;
-    }
-
-    cross_track = vect2_dotprod(vect2_sub(tail_pos, target_tail_pos),
-        target_right);
-    along_remaining = vect2_dotprod(vect2_sub(target_tail_pos, tail_pos),
-        travel_dir);
-    heading_error = rel_hdg(bp.cur_pos.hdg, control_target->end_hdg);
-    feedback = vehicle_tail_steer_correction(
-        control_deadband(cross_track, TAIL_CROSS_TRACK_DEADBAND),
-        control_deadband(heading_error, TAIL_HEADING_DEADBAND),
-        capture_fraction, TAIL_CROSS_TRACK_GAIN, TAIL_HEADING_GAIN,
-        TAIL_MAX_STEER_CORRECTION, seg->backward);
-    path_weight = vehicle_path_terminal_weight(along_remaining,
-        ROUTE_PATH_TERMINAL_FADE_DIST,
-        list_next(&bp.segs, seg) == NULL);
-    path_correction = vehicle_path_steer_correction(route_steer,
-        profile_target, ROUTE_PATH_STEER_DEADBAND,
-        ROUTE_PATH_MAX_CORRECTION, path_weight);
-    target = MIN(MAX(profile_target + path_correction + feedback,
-        -bp.veh.max_steer), bp.veh.max_steer);
-
-    bp_telem.turn_profile_target_deg = profile_target;
-    bp_telem.controller_target_steer_deg = target;
-    bp_telem.tail_feedback_steer_deg = feedback;
-    bp_telem.tail_feedback_weight = capture_weight(capture_fraction);
-    bp_telem.route_path_correction_deg = path_correction;
-    bp_telem.route_path_weight = path_weight;
-    bp_telem.planned_end_x_m = control_target->end_pos.x;
-    bp_telem.planned_end_z_m = control_target->end_pos.y;
-    bp_telem.planned_end_heading_deg = control_target->end_hdg;
-    bp_telem.main_gear_x_m = main_pos.x;
-    bp_telem.main_gear_z_m = main_pos.y;
-    bp_telem.tail_x_m = tail_pos.x;
-    bp_telem.tail_z_m = tail_pos.y;
-    bp_telem.target_tail_x_m = target_tail_pos.x;
-    bp_telem.target_tail_z_m = target_tail_pos.y;
-    bp_telem.tail_cross_track_m = cross_track;
-    bp_telem.tail_along_remaining_m = along_remaining;
-    bp_telem.final_heading_error_deg = heading_error;
-    return (target);
-}
-
 static bool_t
 bp_run_push(bool_t hold_requested) {
 
@@ -2442,7 +2372,7 @@ bp_run_push(bool_t hold_requested) {
         /*
          * The route and steering command are intentionally frozen after the
          * stationary hold is reached. Resume re-enters the normal route
-         * controller with its preserved segment and smoothed steering state.
+         * controller with its preserved segment and legacy steering state.
          */
         push_at_speed(0, bp.veh.max_decel, B_TRUE, B_TRUE);
         return (list_head(&bp.segs) != NULL);
@@ -2457,7 +2387,7 @@ bp_run_push(bool_t hold_requested) {
 
     while (seg != NULL) {
         double steer, speed;
-        bool_t decel = B_FALSE;
+        bool_t decel;
         vehicle_pos_t corr_pos;
 
         /* Pilot pressed brake pedals or set parking brake, stop */
@@ -2468,7 +2398,6 @@ bp_run_push(bool_t hold_requested) {
             dr_setf(&drs.axial_force, 0);
             dr_setf(&drs.rot_force_N, 0);
             bp.last_force = 0;
-            bp.push_accel_limit = 0;
             break;
         }
         /*
@@ -2476,7 +2405,6 @@ bp_run_push(bool_t hold_requested) {
          * the driver changing gear and flipping around.
          */
         if (bp.reverse_t != 0.0) {
-            bp.push_accel_limit = 0;
             if (bp.cur_t - bp.reverse_t < 2 * STATE_TRANS_DELAY) {
                 push_at_speed(0, bp.veh.max_accel, B_TRUE,
                               B_FALSE);
@@ -2487,16 +2415,21 @@ bp_run_push(bool_t hold_requested) {
         corr_pos = corr_acf_pos();
         if (drive_segs(&corr_pos, &bp.veh, &bp.segs,
                        &bp.last_mis_hdg, bp.d_t, &steer, &speed, &decel)) {
-            double nw_defl, target_steer;
+            double nw_defl;
 
             bp_telem.route_steer_cmd_deg = steer;
             telemetry_route_tracking(seg, &corr_pos);
-            target_steer = automatic_steer_target(seg, steer);
-            bp.smooth_steer_cmd = vehicle_steering_step(
-                bp.smooth_steer_cmd, target_steer,
-                TURN_PROFILE_STEER_RATE, bp.d_t);
-            bp_telem.applied_steer_cmd_deg = bp.smooth_steer_cmd;
-            turn_nosewheel(bp.smooth_steer_cmd);
+            if (!nearing_end()) {
+                bp_telem.applied_steer_cmd_deg = steer;
+                turn_nosewheel(steer);
+            } else {
+                /*
+                 * When nearing the end of the route, start neutralizing
+                 * steering early to avoid overshooting the final pose.
+                 */
+                bp_telem.applied_steer_cmd_deg = 0;
+                turn_nosewheel(0);
+            }
             /*
              * Since the drive_segs function returns a longitudinal
              * speed, but push_at_speed controls speed based on the
@@ -2507,32 +2440,20 @@ bp_run_push(bool_t hold_requested) {
             if (hold_requested) {
                 /*
                  * Keep running route and steering control while slowing so
-                 * segment progress and the turn profile remain continuous.
+                 * segment progress and legacy steering remain continuous.
                  * Only the longitudinal target is replaced with zero.
                  */
-                bp.push_accel_limit = 0;
                 push_at_speed(0, bp.veh.max_decel, B_TRUE, B_TRUE);
             } else {
-                bp.push_accel_limit = vehicle_accel_step(
-                    bp.push_accel_limit, bp.veh.max_accel,
-                    PUSH_START_JERK_LIMIT, bp.d_t);
-                push_at_speed(speed, bp.push_accel_limit, B_TRUE, decel);
+                push_at_speed(speed, bp.veh.max_accel, B_TRUE, decel);
             }
             break;
         }
         seg = list_head(&bp.segs);
         if (seg != NULL && seg->backward != last_backward) {
             bp.reverse_t = bp.cur_t;
-            bp.push_accel_limit = 0;
-            bp.turn_profile_active = B_FALSE;
-            bp.turn_profile_distance = 0;
             last_backward = seg->backward;
         }
-    }
-
-    if (seg == NULL) {
-        bp.turn_profile_active = B_FALSE;
-        bp.turn_profile_distance = 0;
     }
 
     return (seg != NULL);
@@ -3230,7 +3151,6 @@ pb_step_pushing(void) {
 
     if (dr_geti(&drs.landing_lights_on) != 0 ||
         dr_geti(&drs.taxi_light_on) != 0) {
-        bp.push_accel_limit = 0;
         if (!slave_mode)
             push_at_speed(0, bp.veh.max_accel, B_TRUE, B_TRUE);
         if (!bp.light_warn) {
@@ -4128,8 +4048,8 @@ tug_pos_update(vect2_t my_pos, double my_hdg, bool_t pos_only) {
 
     tug_spd = tug_speed();
 
-    radius = vehicle_turn_radius(bp_ls.tug->veh.wheelbase,
-        bp_ls.tug->cur_steer);
+    radius = tan(DEG2RAD(90 - bp_ls.tug->cur_steer)) *
+             bp_ls.tug->veh.wheelbase;
     if (pos_only) {
         tug_hdg = bp_ls.tug->pos.hdg;
     } else if (slave_mode) {

--- a/src/bp.h
+++ b/src/bp.h
@@ -95,11 +95,6 @@ typedef struct {
 
     double last_steer;
     double last_force;
-    double push_accel_limit;
-    double turn_profile_distance;
-    double turn_profile_end_hdg;
-    double smooth_steer_cmd;
-    bool_t turn_profile_active;
     bool_t pause_requested;
     bool_t pause_hold;
     bool_t stop_from_pause_hold;

--- a/src/bp.h
+++ b/src/bp.h
@@ -177,6 +177,8 @@ bool_t bp_pause_is_held(void);
 
 bool_t bp_is_awaiting_plan(void);
 
+bool_t bp_can_replan(void);
+
 void bp_get_ground_ops_metrics(double *speed_mps, bool_t *speed_valid,
     double *distance_remaining_m, bool_t *distance_valid);
 

--- a/src/bp_cam.c
+++ b/src/bp_cam.c
@@ -63,8 +63,6 @@
 #include "gate_route_cache.h"
 #include "gate_route_slots.h"
 #include "planner_cache.h"
-#include "realism_config.h"
-#include "vehicle_physics.h"
 #include "xplane.h"
 #include "cfg.h"
 #include "msg.h"
@@ -72,11 +70,6 @@
 #define MAX_PRED_DISTANCE 10000 /* meters */
 #define ANGLE_DRAW_STEP 5
 #define ORIENTATION_LINE_LEN 200
-#define PREDICTION_DT 0.1
-#define PREDICTION_SAMPLE_DISTANCE 1.0
-#define MAX_PREDICTION_STEPS 120000
-#define MAX_PREDICTION_POINTS 20000
-#define DANGER_ZONE_CIRCLE_SEGMENTS 24
 #define PREDICTION_KEY_POSITION_EPSILON 0.01
 #define PREDICTION_KEY_HEADING_EPSILON 0.01
 #define INCR_SMALL 5
@@ -140,25 +133,6 @@ static bool_t force_root_win_focus = B_TRUE;
 static float saved_visibility;
 static int saved_cloud_types[3];
 
-typedef struct {
-    vect2_t pos;
-    double hdg;
-} planner_path_point_t;
-
-typedef struct {
-    bool_t turn_active;
-    double turn_distance;
-    double turn_end_hdg;
-    double steer;
-} planner_prediction_state_t;
-
-static planner_path_point_t planner_path[MAX_PREDICTION_POINTS];
-static float planner_path_height[MAX_PREDICTION_POINTS];
-static size_t planner_path_count;
-static bool_t planner_prediction_announced;
-static bool_t planner_prediction_failure_announced;
-static bool_t planner_band_failure_announced;
-static planner_cache_state_t planner_path_cache;
 static planner_prediction_key_t planner_pred_key;
 static gate_route_context_t planner_gate_context;
 
@@ -574,37 +548,6 @@ planner_committed_signature(void)
         UINT64_C(0x434f4d4d49545445)));
 }
 
-static uint64_t
-planner_prediction_signature(void)
-{
-    uint64_t hash = planner_committed_signature();
-
-    hash = planner_hash_segments(hash, &pred_segs,
-        UINT64_C(0x5052454449435444));
-    hash = planner_hash_double(hash, bp.veh.wheelbase);
-    hash = planner_hash_double(hash, bp.veh.fixed_z_off);
-    hash = planner_hash_double(hash, bp.veh.max_steer);
-    hash = planner_hash_double(hash, bp.veh.max_fwd_spd);
-    hash = planner_hash_double(hash, bp.veh.max_rev_spd);
-    hash = planner_hash_double(hash, bp.veh.max_fwd_ang_vel);
-    hash = planner_hash_double(hash, bp.veh.max_rev_ang_vel);
-    hash = planner_hash_double(hash, bp.veh.max_centr_accel);
-    hash = planner_hash_double(hash, bp.veh.max_accel);
-    hash = planner_hash_double(hash, bp.veh.max_decel);
-    hash = planner_hash_u64(hash, (uint64_t)bp.veh.use_rear_pos);
-    hash = planner_hash_double(hash, bp.acf.main_z);
-    if (bp_ls.outline != NULL) {
-        hash = planner_hash_u64(hash, UINT64_C(1));
-        hash = planner_hash_double(hash, bp_ls.outline->semispan);
-        hash = planner_hash_double(hash, bp_ls.outline->length);
-        hash = planner_hash_u64(hash,
-            (uint64_t)bp_ls.outline->num_pts);
-    } else {
-        hash = planner_hash_u64(hash, UINT64_C(0));
-    }
-    return (hash);
-}
-
 static vect2_t
 planner_aircraft_gear_position(double gear_z)
 {
@@ -617,22 +560,9 @@ planner_aircraft_gear_position(double gear_z)
 }
 
 static vect2_t
-planner_main_gear_position(void)
-{
-    return planner_aircraft_gear_position(bp.acf.main_z);
-}
-
-static vect2_t
 planner_nosewheel_position(void)
 {
     return planner_aircraft_gear_position(bp.acf.nw_z);
-}
-
-static vect2_t
-planner_nosewheel_from_main_gear(vect2_t main_gear, double heading)
-{
-    return vect2_add(main_gear,
-        vect2_scmul(hdg2dir(heading), bp.veh.wheelbase));
 }
 
 static bool_t
@@ -711,8 +641,8 @@ cam_ctl(XPLMCameraPosition_t *pos, int losing_control, void *refcon)
     }
     else
     {
-        /* The steering route is referenced to the aircraft main gear. */
-        start_pos = planner_main_gear_position();
+        start_pos = VECT2(dr_getf(&drs.local_x),
+            -dr_getf(&drs.local_z)); /* inverted X-Plane Z */
         start_hdg = dr_getf(&drs.hdg);
     }
 
@@ -750,6 +680,8 @@ cam_ctl(XPLMCameraPosition_t *pos, int losing_control, void *refcon)
     return (1);
 }
 
+#if 0
+/* Retained for reference only; live and preview steering use legacy paths. */
 static double
 planner_tail_arm(void)
 {
@@ -1179,6 +1111,7 @@ draw_controller_path(void)
     glEnd();
     return (B_TRUE);
 }
+#endif
 
 static void
 draw_segment(const seg_t *seg)
@@ -1195,7 +1128,6 @@ draw_segment(const seg_t *seg)
     {
         float h1, h2;
         vect2_t wing_l, wing_r, p;
-        vect2_t nose_start, nose_end;
 
         // VERIFY3U(XPLMProbeTerrainXYZ(probe, seg->start_pos.x, 0,
         //                              -seg->start_pos.y, &info), ==, xplm_ProbeHitTerrain);
@@ -1220,12 +1152,8 @@ draw_segment(const seg_t *seg)
         glColor3f(0, 0, 1);
         glLineWidth(3);
         glBegin(GL_LINES);
-        nose_start = planner_nosewheel_from_main_gear(seg->start_pos,
-            seg->start_hdg);
-        nose_end = planner_nosewheel_from_main_gear(seg->end_pos,
-            seg->end_hdg);
-        glVertex3f(nose_start.x, h1, -nose_start.y);
-        glVertex3f(nose_end.x, h2, -nose_end.y);
+        glVertex3f(seg->start_pos.x, h1, -seg->start_pos.y);
+        glVertex3f(seg->end_pos.x, h2, -seg->end_pos.y);
         glEnd();
 
         wing_l = vect2_rot(wing_off_l, seg->start_hdg);
@@ -1285,15 +1213,8 @@ draw_segment(const seg_t *seg)
             glColor3f(0, 0, 1);
             glLineWidth(3);
             glBegin(GL_LINES);
-            {
-                vect2_t nose1 = planner_nosewheel_from_main_gear(p1,
-                    seg->start_hdg + a);
-                vect2_t nose2 = planner_nosewheel_from_main_gear(p2,
-                    seg->start_hdg + a + step);
-
-                glVertex3f(nose1.x, info.locationY, -nose1.y);
-                glVertex3f(nose2.x, info.locationY, -nose2.y);
-            }
+            glVertex3f(p1.x, info.locationY, -p1.y);
+            glVertex3f(p2.x, info.locationY, -p2.y);
             glEnd();
 
             glColor3f(1, 0.25, 1);
@@ -1417,21 +1338,13 @@ draw_prediction(XPLMDrawingPhase phase, int before, void *refcon)
 
     XPLMSetGraphicsState(0, 0, 0, 0, 0, 0, 0);
 
-    /*
-     * The blue centerline and magenta danger-zone band now come from the same
-     * controller model used during pushback. Retain the geometric segment
-     * renderer as a safe fallback if a very long or invalid route cannot be
-     * predicted completely.
-     */
-    if (!draw_controller_path()) {
-        for (seg = list_head(&bp.segs); seg != NULL;
-             seg = list_next(&bp.segs, seg))
-            draw_segment(seg);
+    for (seg = list_head(&bp.segs); seg != NULL;
+         seg = list_next(&bp.segs, seg))
+        draw_segment(seg);
 
-        for (seg = list_head(&pred_segs); seg != NULL;
-             seg = list_next(&pred_segs, seg))
-            draw_segment(seg);
-    }
+    for (seg = list_head(&pred_segs); seg != NULL;
+         seg = list_next(&pred_segs, seg))
+        draw_segment(seg);
 
     if ((seg = list_tail(&pred_segs)) != NULL)
     {
@@ -2532,15 +2445,11 @@ bp_cam_start(void)
     XPLMTakeKeyboardFocus(fake_win);
 
     list_create(&pred_segs, sizeof(seg_t), offsetof(seg_t, node));
-    planner_cache_init(&planner_path_cache);
     planner_prediction_key_init(&planner_pred_key);
-    planner_prediction_announced = B_FALSE;
-    planner_prediction_failure_announced = B_FALSE;
-    planner_band_failure_announced = B_FALSE;
     planner_cursor_solve_count = 0;
     planner_cursor_reuse_count = 0;
     planner_gate_route_state_reset();
-    logMsg(BP_INFO_LOG "Planner trajectory cache initialized");
+    logMsg(BP_INFO_LOG "Legacy planner trajectory initialized");
     force_root_win_focus = B_TRUE;
     cam_height = 15 * bp.veh.wheelbase;
     /* We keep the camera position in our coordinates for ease of manip */
@@ -2690,22 +2599,10 @@ bp_cam_stop(void)
         XPLMUnloadObject(cam_lamp_obj);
     cam_lamp_obj = NULL;
 
-    logMsg(BP_INFO_LOG "Planner cache summary: route revisions %llu, path "
-        "builds %llu, path cache hits %llu, cursor solves %llu, cursor reuse "
-        "%llu, failures %llu, terrain probes %llu, average build %.2f ms, "
-        "maximum build %.2f ms, last path points %u",
-        (unsigned long long)planner_path_cache.revision,
-        (unsigned long long)planner_path_cache.build_count,
-        (unsigned long long)planner_path_cache.cache_hit_count,
+    logMsg(BP_INFO_LOG "Legacy planner summary: cursor solves %llu, "
+        "cursor reuse %llu",
         (unsigned long long)planner_cursor_solve_count,
-        (unsigned long long)planner_cursor_reuse_count,
-        (unsigned long long)planner_path_cache.failure_count,
-        (unsigned long long)planner_path_cache.terrain_probe_count,
-        planner_path_cache.build_count != 0 ?
-        (double)planner_path_cache.total_build_us /
-        planner_path_cache.build_count / 1000.0 : 0,
-        planner_path_cache.max_build_us / 1000.0,
-        (unsigned)planner_path_cache.point_count);
+        (unsigned long long)planner_cursor_reuse_count);
     if (!slave_mode && list_head(&bp.segs) != NULL) {
         if (!emergency_tow_allows_persistent_routes()) {
             logMsg(BP_INFO_LOG "Emergency Tow route accepted for this "

--- a/src/cfg.cpp
+++ b/src/cfg.cpp
@@ -33,7 +33,6 @@
 
 #include "bp.h"
 #include "cfg.h"
-#include "ground_ops_ui.h"
 #include "msg.h"
 #include "ui_runtime.h"
 #include "xplane.h"
@@ -128,9 +127,6 @@ const char *crew_language_tooltip =
 
 const char *dev_menu_tooltip = "Show the developer menu options.";
 const char *save_prefs_tooltip = "Save current preferences to disk.";
-const char *disco_when_done_tooltip =
-    "Never ask and always automatically disconnect "
-    "the tug when the pushback operation is complete.";
 const char *per_aircraft_is_global_tooltip =
     "When enabled, all per aircraft settings becomes global.";
 const char *always_connect_tug_first_tooltip =
@@ -152,15 +148,6 @@ const char *ignore_park_brake_tooltip =
 const char *hide_xp11_tug_tooltip =
     "Hides default X-Plane 11 pushback tug.\n"
     "Restart X-Plane for this change to take effect.";
-const char *hide_magic_squares_tooltip =
-    "Hides the shortcut buttons on the left side of the screen.\n"
-    "The first button starts the planner and the second starts the push-back.";
-const char *ground_ops_ui_tooltip =
-    "Enables the compact Ground Operations orb and panel.\n"
-    "When disabled, all classic BetterPushback menu commands remain available.";
-const char *ground_ops_captions_tooltip =
-    "Mirrors active ground-crew audio prompts as text in the read-only "
-    "Ground Operations panel.";
 const char *doors_check_tooltip =
     "Select the action after the doors/GPU/ASU status check is done before starting the push-back.\n"
     "Active with ground crew message: The ground crew will tell you if the doors are not closed.\n"
@@ -174,13 +161,17 @@ const char *monitor_tooltip =
     "automatically.\n"
     "If not select the one that works ! (the monitor numbers are arbitrary).";
 
-const char *magic_squares_height_tooltip =
-    "Slide this bar to move the magic squares up or down.";
-
 const char *eye_tracker_tooltip =
     "Some Eye tracker plugins use the X-plane camera system and therefore "
     "doesn't allow BpB to work properly "
     "while using the planner or the tug view.\n\n"
+    "If it is the case, select the plugin that is in conflit with BpB.\n\n"
+    "CAUTION: At this point, you know what you are doing, selecting the wrong "
+    "plugin may cause X-plane to crash.\n"
+    "Otherwise this setting must be set to : None.";
+
+const char *plugin_acf_tooltip =
+    "Some aircraft plugin may be not compatible with BpB\n"
     "If it is the case, select the plugin that is in conflit with BpB.\n\n"
     "CAUTION: At this point, you know what you are doing, selecting the wrong "
     "plugin may cause X-plane to crash.\n"
@@ -241,11 +232,11 @@ comboList_t sound_device_list = {sound_device_list_, 0, "##sound_device_list",
 comboList_t_ *plg_list_ = nullptr;
 comboList_t plg_list = {plg_list_, 0, "##plg_list", 0};
 
+comboList_t_ *plg_list_acf_ = nullptr;
+comboList_t plg_acf_list = {plg_list_acf_, 0, "##plg_acf_list", 0};
+
 comboList_t_ *doors_check_list_ = nullptr;
 comboList_t doors_check_list = {doors_check_list_, 0, "##doors_check", 0};
-
-comboList_t_ *hide_magic_squares_global_list_ = nullptr;
-comboList_t hide_magic_squares_global_list = {hide_magic_squares_global_list_, 0, "##hide_magic_global", 0};
 
 class SettingsWindow : public XPImgWindow {
 public:
@@ -260,8 +251,8 @@ public:
     comboList_free(&radio_device_list);
     comboList_free(&sound_device_list);
     comboList_free(&plg_list);
+    comboList_free(&plg_acf_list);
     comboList_free(&doors_check_list);
-    comboList_free(&hide_magic_squares_global_list);
   }
 
   bool_t getIsDestroy(void) { return is_destroy; }
@@ -270,11 +261,7 @@ private:
   const char *lang;
   bool_t is_chinese;
   lang_pref_t lang_pref;
-  bool_t disco_when_done;
   bool_t ignore_park_brake;
-  bool_t hide_magic_squares;
-  bool_t ground_ops_ui_enabled;
-  bool_t ground_ops_captions_enabled;
   bool_t dont_hide;
   bool_t always_connect_tug_first;
   bool_t per_aircraft_is_global;
@@ -284,15 +271,12 @@ private:
   bool_t tug_auto_start;
   int monitor_id;
   int for_credit;
-  int magic_squares_height;
   int doors_check;
-  int hide_magic_squares_global;
-  const char *radio_dev, *sound_dev, *plg_to_exclude;
+  const char *radio_dev, *sound_dev, *plg_to_exclude, *plg_acf_to_exclude;
   void LoadConfig(void);
   void sound_comboList_init(comboList_t *list);
   void plugin_comboList_init(comboList_t *list, bool_t only_aircraft);
   void doorscheck_comboList_init(comboList_t *list);
-  void hide_magic_squares_global_comboList_init(comboList_t *list);
   void comboList_free(comboList_t *list);
   void initPerAircraftSettings(void);
 
@@ -312,21 +296,11 @@ SettingsWindow::SettingsWindow(WndMode _mode)
 }
 
 void SettingsWindow::initPerAircraftSettings(void) {
-  disco_when_done = B_FALSE;
-  (void)conf_get_b_per_acf((char *)"disco_when_done", &disco_when_done);
-
   ignore_park_brake = B_FALSE;
   (void)conf_get_b_per_acf((char *)"ignore_park_brake", &ignore_park_brake);
 
   doors_check = DOOR_CHECK_ActiveWithMessage;
   (void)conf_get_i_per_acf((char *)"doors_check", &doors_check);
-
-  hide_magic_squares = B_FALSE;
-  (void)conf_get_b_per_acf((char *)"hide_magic_squares", &hide_magic_squares);
-
-  magic_squares_height = 50;
-  (void)conf_get_i_per_acf((char *)"magic_squares_height",
-                           &magic_squares_height);
 
 }
 void SettingsWindow::LoadConfig(void) {
@@ -364,13 +338,6 @@ void SettingsWindow::LoadConfig(void) {
 
   tug_starts_next_plane = B_FALSE;
   (void)conf_get_b(bp_conf, "tug_starts_next_plane", &tug_starts_next_plane);
-
-  ground_ops_ui_enabled = B_TRUE;
-  (void)conf_get_b(bp_conf, "ground_ops_ui_enabled",
-                   &ground_ops_ui_enabled);
-  ground_ops_captions_enabled = B_TRUE;
-  (void)conf_get_b(bp_conf, "ground_ops_captions_enabled",
-                   &ground_ops_captions_enabled);
 
 // feature disabled for now
 //  tug_auto_start = B_FALSE;
@@ -426,13 +393,22 @@ void SettingsWindow::LoadConfig(void) {
     }
   }  
 
+  plg_acf_to_exclude = NULL;
+  plugin_comboList_init(&plg_acf_list, B_TRUE);
+  plg_acf_list.selected = 0;
+  if (conf_get_str_per_acf((char *)"plg_acf_to_exclude",
+                          (char **)&plg_acf_to_exclude)) {
+    for (int i = 0; i < plg_acf_list.list_size; i++) {
+      if (strcmp(plg_acf_to_exclude,
+                 plg_acf_list.combo_list[i].value) == 0) {
+        plg_acf_list.selected = i;
+        break;
+      }
+    }
+  }
+
   doorscheck_comboList_init(&doors_check_list);
   doors_check_list.selected = doors_check;
-
-  hide_magic_squares_global_comboList_init(&hide_magic_squares_global_list);
-  hide_magic_squares_global = HIDE_M_SQUARE_USE_ACF_SETTING;
-  (void)conf_get_i( bp_conf,"hide_magic_squares_global", &hide_magic_squares_global);
-  hide_magic_squares_global_list.selected = hide_magic_squares_global;
 }
 
 void SettingsWindow::plugin_comboList_init(comboList_t *list,  bool_t only_aircraft) {
@@ -511,25 +487,6 @@ void SettingsWindow::doorscheck_comboList_init(comboList_t *list) {
     list->combo_list[i].value = strdup("");
   }
 }
-
-void SettingsWindow::hide_magic_squares_global_comboList_init(comboList_t *list) {
-  list->combo_list = (comboList_t_ *)safe_calloc(3, sizeof(comboList_t_));
-  list->list_size = 3;
-
-  // These should follow the order of the DoorCheck enum
-  static const char* hide_square_strings[] = {
-    _("Use Aircraft setting"),
-    _("Yes"),
-    _("No")
-  };
-
-  for (int i = 0; i < 3; ++i) {
-    list->combo_list[i].string = strdup(hide_square_strings[i]);
-    list->combo_list[i].use_chinese = B_FALSE;
-    list->combo_list[i].value = strdup("");
-  }
-}
-
 
 void SettingsWindow::comboList_free(comboList_t *list) {
   for (size_t i = 0; i < list->list_size; i++) {
@@ -720,16 +677,6 @@ void SettingsWindow::buildInterface() {
     } */
     ImGui::TableNextRow();
     ImGui::TableNextColumn();
-    ImGui::Text("%s", _("Auto disconnect when done"));
-    Tooltip(_(disco_when_done_tooltip));
-
-    ImGui::TableNextColumn();
-    if (ImGui::Checkbox("##disco_when_done_cbox", (bool *)&disco_when_done)) {
-      conf_set_b_per_acf((char *)"disco_when_done", disco_when_done);
-    }
-
-    ImGui::TableNextRow();
-    ImGui::TableNextColumn();
     ImGui::Text("%s", _("Ignore check parking brake is set"));
     Tooltip(_(ignore_park_brake_tooltip));
 
@@ -752,27 +699,18 @@ void SettingsWindow::buildInterface() {
 
     ImGui::TableNextRow();
     ImGui::TableNextColumn();
-    ImGui::Text("%s", _("Hide the magic squares"));
-    Tooltip(_(hide_magic_squares_tooltip));
-
-    ImGui::TableNextColumn();
-    if (ImGui::Checkbox("##hide_magic_squares_cbox",
-                        (bool *)&hide_magic_squares)) {
-      conf_set_b_per_acf((char *)"hide_magic_squares", hide_magic_squares);
-    }
-
-    ImGui::TableNextRow();
-    ImGui::TableNextColumn();
-    ImGui::Text("%s", _("Magic squares position"));
-    Tooltip(_(magic_squares_height_tooltip));
+    ImGui::Text("%s", _("ACF Plugin Exclusion (Experimental)"));
+    Tooltip(_(plugin_acf_tooltip));
 
     ImGui::TableNextColumn();
     ImGui::SetNextItemWidth(combowithWidth);
-    if (ImGui::SliderInt("##magic_position", &magic_squares_height, 20, 80,
-                         "%d %%")) {
-      conf_set_i_per_acf((char *)"magic_squares_height",
-                         (int)magic_squares_height);
-      main_intf_hide();
+    if (comboList(&plg_acf_list)) {
+      if (plg_acf_list.selected == 0) {
+        conf_set_str_per_acf((char *)"plg_acf_to_exclude", NULL);
+      } else {
+        conf_set_str_per_acf((char *)"plg_acf_to_exclude",
+            (char *)plg_acf_list.combo_list[plg_acf_list.selected].value);
+      }
     }
 
     ImGui::TableNextRow();
@@ -797,42 +735,6 @@ void SettingsWindow::buildInterface() {
     ImGui::GetWindowDrawList()->AddLine(rowBottomStart, rowBottomEnd,
                                         LINE_COLOR, LINE_THICKNESS);
 
-    ImGui::TableNextRow();
-    ImGui::TableNextColumn();
-    ImGui::Text("%s", _("Hide the magic squares"));
-    Tooltip(_(hide_magic_squares_tooltip));
-
-    ImGui::TableNextColumn();
-    ImGui::SetNextItemWidth(combowithWidth);
-    if (comboList(&hide_magic_squares_global_list)) {
-      (void)conf_set_i(bp_conf,"hide_magic_squares_global", hide_magic_squares_global_list.selected);
-    }
-
-    ImGui::TableNextRow();
-    ImGui::TableNextColumn();
-    ImGui::Text("%s", _("Enable Ground Operations UI"));
-    Tooltip(_(ground_ops_ui_tooltip));
-
-    ImGui::TableNextColumn();
-    if (ImGui::Checkbox("##ground_ops_ui_enabled",
-                        (bool *)&ground_ops_ui_enabled)) {
-      (void)conf_set_b(bp_conf, "ground_ops_ui_enabled",
-                       ground_ops_ui_enabled);
-    }
-
-    ImGui::TableNextRow();
-    ImGui::TableNextColumn();
-    ImGui::Text("%s", _("Show Ground Operations captions"));
-    Tooltip(_(ground_ops_captions_tooltip));
-
-    ImGui::TableNextColumn();
-    if (ImGui::Checkbox("##ground_ops_captions_enabled",
-                        (bool *)&ground_ops_captions_enabled)) {
-      (void)conf_set_b(bp_conf, "ground_ops_captions_enabled",
-                       ground_ops_captions_enabled);
-      ground_ops_ui_set_captions_enabled(ground_ops_captions_enabled);
-    }
-    
     ImGui::TableNextRow();
     ImGui::TableNextColumn();
     ImGui::Text("%s", _("Always connect the tug first"));

--- a/src/driving.c
+++ b/src/driving.c
@@ -36,7 +36,6 @@
 #include <XPLMUtilities.h>
 
 #include "driving.h"
-#include "vehicle_physics.h"
 #include "xplane.h"
 
 #define    SEG_TURN_MULT        0.9    /* leave 10% for oversteer */
@@ -188,8 +187,8 @@ compute_segs_impl(const vehicle_t *veh, vect2_t start_pos, double start_hdg,
      * SEG_TURN_MULT), to allow for some oversteering correction.
      * Also limit the radius to something sensible (MIN_TURN_RADIUS).
      */
-    min_radius = MAX(fabs(vehicle_turn_radius(veh->wheelbase,
-        veh->max_steer * SEG_TURN_MULT)), MIN_TURN_RADIUS);
+    min_radius = MAX(tan(DEG2RAD(90 - (veh->max_steer * SEG_TURN_MULT))) *
+                     veh->wheelbase, MIN_TURN_RADIUS);
 
     /*
      * If the amount of heading change is tiny, just project the desired
@@ -504,12 +503,8 @@ straight_run_speed(const vehicle_t *veh, list_t *segs, double rmng_d,
     cruise_spd = (backward ? veh->max_rev_spd : veh->max_fwd_spd);
     crawl_spd = CRAWL_SPEED(bp_xp_ver, veh);
 
-    if (rmng_d < crawl_spd) {
-        spd = MAX(next_spd, crawl_spd);
-        if (out_decelerating != NULL)
-            *out_decelerating = (spd < cruise_spd);
-        return (spd);
-    }
+    if (rmng_d < crawl_spd)
+        return (MAX(next_spd, crawl_spd));
 
     /*
      * Pretend we have less distance left so as to reach our target speed
@@ -684,9 +679,7 @@ ang_vel_speed_limit(const vehicle_t *veh, double steer, double speed) {
 
     if (speed == 0)
         return (0);
-    if (ABS(steer) < 1e-6)
-        return (speed);
-    turn_radius = fabs(vehicle_turn_radius(veh->wheelbase, steer));
+    turn_radius = tan(DEG2RAD(90 - ABS(steer))) * veh->wheelbase;
     ang_vel = RAD2DEG(ABS(speed) / turn_radius);
     if (speed >= 0)
         speed *= MIN(veh->max_fwd_ang_vel / ang_vel, 1);

--- a/src/gate_route_cache.c
+++ b/src/gate_route_cache.c
@@ -413,7 +413,8 @@ route_initial_pose_matches(const gate_route_context_t *context,
 
     if (first == NULL)
         return B_FALSE;
-    gate_route_point_from_relative(0, -context->wheelbase,
+    /* Legacy planner segments begin at the aircraft reference point. */
+    gate_route_point_from_relative(0, context->nw_z,
         context->anchor_local.x, context->anchor_local.y,
         context->frame_hdg, &expected_x, &expected_y);
     return hypot(first->start_pos.x - expected_x,

--- a/src/ground_ops_state.c
+++ b/src/ground_ops_state.c
@@ -112,6 +112,7 @@ raw_equal(const ground_ops_raw_state_t *left,
         left->plan_complete == right->plan_complete &&
         left->planner_open == right->planner_open &&
         left->awaiting_plan == right->awaiting_plan &&
+        left->replan_available == right->replan_available &&
         left->pause_requested == right->pause_requested &&
         left->pause_held == right->pause_held &&
         strcmp(left->airport_ident, right->airport_ident) == 0 &&
@@ -145,6 +146,7 @@ semantic_equal(const ground_ops_raw_state_t *left,
         left->plan_complete == right->plan_complete &&
         left->planner_open == right->planner_open &&
         left->awaiting_plan == right->awaiting_plan &&
+        left->replan_available == right->replan_available &&
         left->pause_requested == right->pause_requested &&
         left->pause_held == right->pause_held &&
         strcmp(left->airport_ident, right->airport_ident) == 0 &&
@@ -163,6 +165,7 @@ normalize_raw(const ground_ops_raw_state_t *input)
         raw.step = PB_STEP_OFF;
         raw.prep_state_active = true;
         raw.awaiting_plan = false;
+        raw.replan_available = false;
         raw.pause_requested = false;
         raw.pause_held = false;
     }
@@ -359,6 +362,10 @@ map_step(const ground_ops_raw_state_t *raw,
             set_view(snapshot, GROUND_OPS_STAGE_COMMS, "ACTION",
                 "Ready for brake release", "Tug connected and crew ready",
                 "Release the parking brake", true);
+            if (raw->replan_available) {
+                set_actions(snapshot, GROUND_OPS_ACTION_CHANGE_PLAN,
+                    "Change plan", GROUND_OPS_ACTION_NONE, "");
+            }
         }
         break;
     case PB_STEP_STARTING:
@@ -416,9 +423,9 @@ map_step(const ground_ops_raw_state_t *raw,
             "Wait for nose-gear release", false);
         break;
     case PB_STEP_WAITING4OK2DISCO:
-        set_view(snapshot, GROUND_OPS_STAGE_CLEAR, "ACTION",
-            "Ready to disconnect", "Ground crew is awaiting approval",
-            "Confirm tug disconnection", true);
+        set_view(snapshot, GROUND_OPS_STAGE_CLEAR, "ACTIVE",
+            "Disconnecting the tug", "Disconnection is automatic",
+            "Wait for the tug to move clear", false);
         break;
     case PB_STEP_MOVING_AWAY:
         set_view(snapshot, GROUND_OPS_STAGE_CLEAR, "ACTIVE",

--- a/src/ground_ops_state.c
+++ b/src/ground_ops_state.c
@@ -241,7 +241,7 @@ map_prep(const ground_ops_raw_state_t *raw,
         snapshot->operation_complete = true;
         set_view(snapshot, GROUND_OPS_STAGE_CLEAR, "COMPLETE",
             "Ground operation complete", "Aircraft and equipment are clear",
-            "Call tow assistance if the aircraft must return", false);
+            "Call tow assistance if the\naircraft must return", false);
         set_actions(snapshot, GROUND_OPS_ACTION_CALL_EMERGENCY_TOW,
             "Call tow back", GROUND_OPS_ACTION_NONE, "");
         break;

--- a/src/ground_ops_state.h
+++ b/src/ground_ops_state.h
@@ -76,6 +76,7 @@ typedef enum {
     GROUND_OPS_ACTION_CALL_TUG,
     GROUND_OPS_ACTION_CALL_EMERGENCY_TOW,
     GROUND_OPS_ACTION_OPEN_PLANNER,
+    GROUND_OPS_ACTION_CHANGE_PLAN,
     GROUND_OPS_ACTION_PAUSE,
     GROUND_OPS_ACTION_RESUME,
     GROUND_OPS_ACTION_END_DISCONNECT
@@ -92,6 +93,7 @@ typedef struct {
     bool plan_complete;
     bool planner_open;
     bool awaiting_plan;
+    bool replan_available;
     bool pause_requested;
     bool pause_held;
     char airport_ident[8];

--- a/src/ground_ops_ui.cpp
+++ b/src/ground_ops_ui.cpp
@@ -10,6 +10,7 @@
  */
 
 #include <cmath>
+#include <cfloat>
 #include <cstdio>
 #include <cstdint>
 #include <new>
@@ -54,6 +55,7 @@ enum class UiAction {
     CallTug,
     CallEmergencyTow,
     OpenPlanner,
+    ChangePlan,
     PausePush,
     ResumePush,
     ArmEndOperation,
@@ -306,6 +308,7 @@ collect_raw_state(void)
     raw.plan_complete = (plan_complete != B_FALSE);
     raw.planner_open = (planner_open != B_FALSE);
     raw.awaiting_plan = (bp_is_awaiting_plan() != B_FALSE);
+    raw.replan_available = (bp_can_replan() != B_FALSE);
     raw.pause_requested = (bp_pause_is_requested() != B_FALSE);
     raw.pause_held = (bp_pause_is_held() != B_FALSE);
     ground_ops_data_format(&data_context, context_now_s(), &data);
@@ -426,7 +429,8 @@ recover_rect(ground_ops_rect_t *rect, int width, int height,
     MonitorCollection collection = collect_monitors(os_coordinates);
     bool recovered = ground_ops_rect_recover(rect, width, height,
         collection.monitors, collection.count, preferred_monitor,
-        GROUND_OPS_WINDOW_MARGIN, GROUND_OPS_VISIBLE_MINIMUM);
+        ground_ops_scaled_pixels(GROUND_OPS_WINDOW_MARGIN),
+        ground_ops_scaled_pixels(GROUND_OPS_VISIBLE_MINIMUM));
 
     if (recovered)
         geometry_recoveries++;
@@ -510,6 +514,16 @@ private:
     bool orb_press_active = false;
     ground_ops_rect_t orb_press_rect = {};
 
+    static float scaled(float value)
+    {
+        return (value * static_cast<float>(ground_ops_ui_scale()));
+    }
+
+    static ImVec2 point(float x, float y)
+    {
+        return (ImVec2(scaled(x), scaled(y)));
+    }
+
     void apply_presentation_contract()
     {
         int width, height;
@@ -519,7 +533,8 @@ private:
         if (current_presentation == GROUND_OPS_PRESENTATION_ORB)
             SetWindowDragArea(0, 0, width, height);
         else
-            SetWindowDragArea(0, 0, width - 90, 45);
+            SetWindowDragArea(0, 0, width - ground_ops_scaled_pixels(90),
+                ground_ops_scaled_pixels(45));
     }
 
     static void tooltip(const char *message)
@@ -533,21 +548,37 @@ private:
         if (message == nullptr || message[0] == '\0' ||
             !ImGui::IsItemHovered(hover_flags))
             return;
+        ImVec2 window_pos = ImGui::GetWindowPos();
+        ImVec2 window_size = ImGui::GetWindowSize();
+        float wrap_width = scaled(220.0f);
+        bool inside_panel = window_size.x >=
+            scaled(GROUND_OPS_PANEL_WIDTH - 1.0f);
+
+        if (inside_panel) {
+            wrap_width = window_size.x - scaled(32.0f);
+            ImGui::SetNextWindowPos(ImVec2(window_pos.x + scaled(8.0f),
+                window_pos.y + scaled(48.0f)), ImGuiCond_Always);
+        }
+        ImGui::SetNextWindowSizeConstraints(ImVec2(scaled(80.0f), 0),
+            ImVec2(wrap_width + scaled(16.0f), FLT_MAX));
         ImGui::BeginTooltip();
+        ImGui::PushTextWrapPos(wrap_width);
         ImGui::TextUnformatted(message);
+        ImGui::PopTextWrapPos();
         ImGui::EndTooltip();
     }
 
     static void draw_text(ImDrawList *draw, float size, float x, float y,
         ImU32 color, const char *text)
     {
-        draw->AddText(ImGui::GetFont(), size, ImVec2(x, y), color, text);
+        draw->AddText(ImGui::GetFont(), scaled(size), point(x, y), color,
+            text);
     }
 
     static ImVec2 measure_text(float size, const char *text)
     {
-        return (ImGui::GetFont()->CalcTextSizeA(size, 10000.0f, 0.0f,
-            text));
+        return (ImGui::GetFont()->CalcTextSizeA(scaled(size),
+            scaled(10000.0f), 0.0f, text));
     }
 
     static void draw_text_centered(ImDrawList *draw, float size,
@@ -555,7 +586,8 @@ private:
     {
         ImVec2 measured = measure_text(size, text);
 
-        draw_text(draw, size, center_x - measured.x / 2.0f, y, color,
+        draw->AddText(ImGui::GetFont(), scaled(size),
+            ImVec2(scaled(center_x) - measured.x / 2.0f, scaled(y)), color,
             text);
     }
 
@@ -564,24 +596,27 @@ private:
     {
         ImVec2 measured = measure_text(size, text);
 
-        draw_text(draw, size, right - measured.x, y, color, text);
+        draw->AddText(ImGui::GetFont(), scaled(size),
+            ImVec2(scaled(right) - measured.x, scaled(y)), color, text);
     }
 
     static bool icon_button(ImDrawList *draw, const char *id, float x,
         float y, const char *icon, const char *help)
     {
-        const ImVec2 size(25.0f, 27.0f);
+        const ImVec2 size = point(25.0f, 27.0f);
         const ImU32 hovered = IM_COL32(41, 50, 58, 255);
         const ImU32 foreground = IM_COL32(181, 191, 199, 255);
 
-        ImGui::SetCursorPos(ImVec2(x, y));
+        ImGui::SetCursorPos(point(x, y));
         bool pressed = ImGui::InvisibleButton(id, size);
         if (ImGui::IsItemHovered())
-            draw->AddRectFilled(ImVec2(x, y), ImVec2(x + size.x,
-                y + size.y), hovered, 7.0f);
+            draw->AddRectFilled(point(x, y),
+                ImVec2(scaled(x) + size.x, scaled(y) + size.y), hovered,
+                scaled(7.0f));
         ImVec2 measured = measure_text(13.0f, icon);
-        draw_text(draw, 13.0f, x + (size.x - measured.x) / 2.0f,
-            y + (size.y - measured.y) / 2.0f, foreground, icon);
+        draw->AddText(ImGui::GetFont(), scaled(13.0f),
+            ImVec2(scaled(x) + (size.x - measured.x) / 2.0f,
+            scaled(y) + (size.y - measured.y) / 2.0f), foreground, icon);
         tooltip(help);
         return (pressed);
     }
@@ -590,7 +625,7 @@ private:
         float x, float y, float width, const char *label, bool destructive,
         const char *help)
     {
-        const ImVec2 size(width, 35.0f);
+        const ImVec2 size = point(width, 35.0f);
         ImU32 fill = destructive ? IM_COL32(76, 42, 38, 255) :
             IM_COL32(25, 67, 84, 255);
         ImU32 hovered = destructive ? IM_COL32(105, 52, 45, 255) :
@@ -600,12 +635,12 @@ private:
         ImU32 foreground = destructive ? IM_COL32(255, 210, 199, 255) :
             IM_COL32(220, 239, 247, 255);
 
-        ImGui::SetCursorPos(ImVec2(x, y));
+        ImGui::SetCursorPos(point(x, y));
         bool pressed = ImGui::InvisibleButton(id, size);
-        draw->AddRectFilled(ImVec2(x, y), ImVec2(x + width, y + size.y),
-            ImGui::IsItemHovered() ? hovered : fill, 6.0f);
-        draw->AddRect(ImVec2(x, y), ImVec2(x + width, y + size.y), border,
-            6.0f, 0, 1.0f);
+        draw->AddRectFilled(point(x, y), point(x + width, y + 35.0f),
+            ImGui::IsItemHovered() ? hovered : fill, scaled(6.0f));
+        draw->AddRect(point(x, y), point(x + width, y + 35.0f), border,
+            scaled(6.0f), 0, scaled(1.0f));
         draw_text_centered(draw, 10.5f, x + width / 2.0f, y + 10.0f,
             foreground, label);
         tooltip(help);
@@ -621,6 +656,8 @@ private:
             return (UiAction::CallEmergencyTow);
         case GROUND_OPS_ACTION_OPEN_PLANNER:
             return (UiAction::OpenPlanner);
+        case GROUND_OPS_ACTION_CHANGE_PLAN:
+            return (UiAction::ChangePlan);
         case GROUND_OPS_ACTION_PAUSE:
             return (UiAction::PausePush);
         case GROUND_OPS_ACTION_RESUME:
@@ -655,14 +692,15 @@ private:
         if (snapshot == nullptr)
             return;
 
-        draw->AddRectFilled(ImVec2(3, 4),
-            ImVec2(GROUND_OPS_ORB_WIDTH, GROUND_OPS_ORB_HEIGHT), shadow,
-            11.0f);
-        draw->AddRectFilled(ImVec2(1, 1),
-            ImVec2(GROUND_OPS_ORB_WIDTH - 2,
-            GROUND_OPS_ORB_HEIGHT - 2), background, 10.0f);
-        draw->AddRect(ImVec2(1, 1), ImVec2(GROUND_OPS_ORB_WIDTH - 2,
-            GROUND_OPS_ORB_HEIGHT - 2), border, 10.0f, 0, 1.0f);
+        draw->AddRectFilled(point(3, 4),
+            point(GROUND_OPS_ORB_WIDTH, GROUND_OPS_ORB_HEIGHT), shadow,
+            scaled(11.0f));
+        draw->AddRectFilled(point(1, 1),
+            point(GROUND_OPS_ORB_WIDTH - 2,
+            GROUND_OPS_ORB_HEIGHT - 2), background, scaled(10.0f));
+        draw->AddRect(point(1, 1), point(GROUND_OPS_ORB_WIDTH - 2,
+            GROUND_OPS_ORB_HEIGHT - 2), border, scaled(10.0f), 0,
+            scaled(1.0f));
 
         for (int index = 0; index < 5; index++) {
             float center_y = 18.0f + index * 47.0f;
@@ -672,38 +710,40 @@ private:
                 current_text : secondary;
 
             if (index != 0) {
-                draw->AddLine(ImVec2(29, center_y - 40),
-                    ImVec2(29, center_y - 7),
+                draw->AddLine(point(29, center_y - 40),
+                    point(29, center_y - 7),
                     snapshot->stages[index - 1] == GROUND_OPS_STAGE_COMPLETE ?
-                    complete : connector, 2.0f);
+                    complete : connector, scaled(2.0f));
             }
             if (progress == GROUND_OPS_STAGE_COMPLETE) {
-                draw->AddCircleFilled(ImVec2(29, center_y), 6, complete, 24);
-                draw->AddCircle(ImVec2(29, center_y), 7,
-                    complete_text, 24, 1.0f);
+                draw->AddCircleFilled(point(29, center_y), scaled(6),
+                    complete, 24);
+                draw->AddCircle(point(29, center_y), scaled(7),
+                    complete_text, 24, scaled(1.0f));
             } else if (progress == GROUND_OPS_STAGE_CURRENT) {
-                draw->AddCircleFilled(ImVec2(29, center_y), 6, current, 24);
-                draw->AddCircle(ImVec2(29, center_y), 7,
-                    current_text, 24, 1.0f);
+                draw->AddCircleFilled(point(29, center_y), scaled(6),
+                    current, 24);
+                draw->AddCircle(point(29, center_y), scaled(7),
+                    current_text, 24, scaled(1.0f));
                 if (snapshot->action_required) {
-                    draw->AddCircleFilled(ImVec2(47, center_y - 7), 6,
-                        amber, 20);
+                    draw->AddCircleFilled(point(47, center_y - 7),
+                        scaled(6), amber, 20);
                     draw_text_centered(draw, 9.0f, 47.0f, center_y - 12,
                         IM_COL32(31, 27, 18, 255), "!");
                 }
             } else {
-                draw->AddCircleFilled(ImVec2(29, center_y), 5,
+                draw->AddCircleFilled(point(29, center_y), scaled(5),
                     background, 20);
-                draw->AddCircle(ImVec2(29, center_y), 6, inactive, 20,
-                    2.0f);
+                draw->AddCircle(point(29, center_y), scaled(6), inactive,
+                    20, scaled(2.0f));
             }
             draw_text_centered(draw, 10.0f, 29.0f, center_y + 9.0f,
                 label, stages[index]);
         }
 
-        ImGui::SetCursorPos(ImVec2(0, 0));
+        ImGui::SetCursorPos(point(0, 0));
         bool pressed = ImGui::InvisibleButton("##ground_ops_stage_rail",
-            ImVec2(GROUND_OPS_ORB_WIDTH, GROUND_OPS_ORB_HEIGHT));
+            point(GROUND_OPS_ORB_WIDTH, GROUND_OPS_ORB_HEIGHT));
         if (ImGui::IsItemActivated()) {
             orb_press_active = true;
             orb_press_rect = to_rect(GetCurrentWindowGeometry());
@@ -714,7 +754,7 @@ private:
             int dy = current.top - orb_press_rect.top;
 
             if (ground_ops_click_is_activation(dx, dy,
-                GROUND_OPS_CLICK_DRAG_THRESHOLD)) {
+                ground_ops_scaled_pixels(GROUND_OPS_CLICK_DRAG_THRESHOLD))) {
                 click_expansions++;
                 queue_action(UiAction::ShowPanel);
             } else {
@@ -752,33 +792,34 @@ private:
         if (snapshot == nullptr)
             return;
 
-        draw->AddRectFilled(ImVec2(3, 4),
-            ImVec2(GROUND_OPS_PANEL_WIDTH, GROUND_OPS_PANEL_HEIGHT),
-            IM_COL32(0, 0, 0, 105), 11.0f);
-        draw->AddRectFilled(ImVec2(1, 1),
-            ImVec2(GROUND_OPS_PANEL_WIDTH - 2,
-            GROUND_OPS_PANEL_HEIGHT - 2), background, 10.0f);
-        draw->AddRectFilled(ImVec2(2, 2),
-            ImVec2(GROUND_OPS_PANEL_WIDTH - 2, 45), top_bar, 9.0f);
-        draw->AddRectFilled(ImVec2(2, 12),
-            ImVec2(GROUND_OPS_PANEL_WIDTH - 2, 45), top_bar, 0.0f);
-        draw->AddRectFilled(ImVec2(2, 46),
-            ImVec2(GROUND_OPS_PANEL_WIDTH - 2, 99), section, 0.0f);
-        draw->AddRectFilled(ImVec2(2, 99), ImVec2(59, 350), section,
-            0.0f);
-        draw->AddRectFilled(ImVec2(2, 390),
-            ImVec2(GROUND_OPS_PANEL_WIDTH - 2,
+        draw->AddRectFilled(point(3, 4),
+            point(GROUND_OPS_PANEL_WIDTH, GROUND_OPS_PANEL_HEIGHT),
+            IM_COL32(0, 0, 0, 105), scaled(11.0f));
+        draw->AddRectFilled(point(1, 1),
+            point(GROUND_OPS_PANEL_WIDTH - 2,
+            GROUND_OPS_PANEL_HEIGHT - 2), background, scaled(10.0f));
+        draw->AddRectFilled(point(2, 2),
+            point(GROUND_OPS_PANEL_WIDTH - 2, 45), top_bar, scaled(9.0f));
+        draw->AddRectFilled(point(2, 12),
+            point(GROUND_OPS_PANEL_WIDTH - 2, 45), top_bar, 0.0f);
+        draw->AddRectFilled(point(2, 46),
+            point(GROUND_OPS_PANEL_WIDTH - 2, 99), section, 0.0f);
+        draw->AddRectFilled(point(2, 99), point(59, 350), section, 0.0f);
+        draw->AddRectFilled(point(2, 390),
+            point(GROUND_OPS_PANEL_WIDTH - 2,
             GROUND_OPS_PANEL_HEIGHT - 2), section, 0.0f);
-        draw->AddRect(ImVec2(1, 1),
-            ImVec2(GROUND_OPS_PANEL_WIDTH - 2,
-            GROUND_OPS_PANEL_HEIGHT - 2), border, 10.0f, 0, 1.0f);
-        draw->AddLine(ImVec2(2, 45), ImVec2(GROUND_OPS_PANEL_WIDTH - 2,
-            45), rule, 1.0f);
-        draw->AddLine(ImVec2(2, 99), ImVec2(GROUND_OPS_PANEL_WIDTH - 2,
-            99), rule, 1.0f);
-        draw->AddLine(ImVec2(59, 99), ImVec2(59, 350), rule, 1.0f);
-        draw->AddLine(ImVec2(2, 390), ImVec2(GROUND_OPS_PANEL_WIDTH - 2,
-            390), rule, 1.0f);
+        draw->AddRect(point(1, 1),
+            point(GROUND_OPS_PANEL_WIDTH - 2,
+            GROUND_OPS_PANEL_HEIGHT - 2), border, scaled(10.0f), 0,
+            scaled(1.0f));
+        draw->AddLine(point(2, 45), point(GROUND_OPS_PANEL_WIDTH - 2,
+            45), rule, scaled(1.0f));
+        draw->AddLine(point(2, 99), point(GROUND_OPS_PANEL_WIDTH - 2,
+            99), rule, scaled(1.0f));
+        draw->AddLine(point(59, 99), point(59, 350), rule,
+            scaled(1.0f));
+        draw->AddLine(point(2, 390), point(GROUND_OPS_PANEL_WIDTH - 2,
+            390), rule, scaled(1.0f));
 
         draw_text(draw, 11.0f, 10, 15, muted, "::");
         draw_text(draw, 14.0f, 30, 8, primary, "Ground operations");
@@ -809,37 +850,39 @@ private:
                 blue_text : muted;
 
             if (index != 0) {
-                draw->AddLine(ImVec2(30, center_y - 39),
-                    ImVec2(30, center_y - 7),
+                draw->AddLine(point(30, center_y - 39),
+                    point(30, center_y - 7),
                     snapshot->stages[index - 1] == GROUND_OPS_STAGE_COMPLETE ?
-                    green : rule, 2.0f);
+                    green : rule, scaled(2.0f));
             }
             if (progress == GROUND_OPS_STAGE_COMPLETE) {
-                draw->AddCircleFilled(ImVec2(30, center_y), 6, green, 24);
-                draw->AddCircle(ImVec2(30, center_y), 7,
-                    green_text, 24, 1.0f);
+                draw->AddCircleFilled(point(30, center_y), scaled(6), green,
+                    24);
+                draw->AddCircle(point(30, center_y), scaled(7), green_text,
+                    24, scaled(1.0f));
             } else if (progress == GROUND_OPS_STAGE_CURRENT) {
-                draw->AddCircleFilled(ImVec2(30, center_y), 6,
+                draw->AddCircleFilled(point(30, center_y), scaled(6),
                     IM_COL32(30, 111, 145, 255), 24);
-                draw->AddCircle(ImVec2(30, center_y), 7, blue_text, 24,
-                    1.0f);
+                draw->AddCircle(point(30, center_y), scaled(7), blue_text,
+                    24, scaled(1.0f));
                 if (snapshot->action_required) {
-                    draw->AddCircleFilled(ImVec2(49, center_y - 7), 6,
-                        amber, 20);
+                    draw->AddCircleFilled(point(49, center_y - 7),
+                        scaled(6), amber, 20);
                     draw_text_centered(draw, 9.0f, 49.0f, center_y - 12,
                         IM_COL32(31, 27, 18, 255), "!");
                 }
             } else {
-                draw->AddCircleFilled(ImVec2(30, center_y), 5, section, 20);
-                draw->AddCircle(ImVec2(30, center_y), 6,
-                    IM_COL32(78, 90, 100, 255), 20, 2.0f);
+                draw->AddCircleFilled(point(30, center_y), scaled(5),
+                    section, 20);
+                draw->AddCircle(point(30, center_y), scaled(6),
+                    IM_COL32(78, 90, 100, 255), 20, scaled(2.0f));
             }
             draw_text_centered(draw, 10.0f, 30.0f, center_y + 9.0f,
                 label, stages[index]);
         }
 
-        draw->AddRectFilled(ImVec2(73, 116), ImVec2(108, 151), blue_panel,
-            9.0f);
+        draw->AddRectFilled(point(73, 116), point(108, 151), blue_panel,
+            scaled(9.0f));
         draw_text_centered(draw, 13.0f, 90.5f, 126, blue_text,
             snapshot->stage == GROUND_OPS_STAGE_TUG ? "TG" :
             snapshot->stage == GROUND_OPS_STAGE_CONNECT ? "CN" :
@@ -857,13 +900,14 @@ private:
         draw_text(draw, 10.0f, 73, 253, secondary, snapshot->speed);
         draw_text(draw, 10.0f, 176, 253, secondary, snapshot->distance);
 
-        draw->AddRectFilled(ImVec2(73, 282), ImVec2(279, 327),
-            snapshot->action_required ? amber_panel : top_bar, 7.0f);
-        draw->AddRect(ImVec2(73, 282), ImVec2(279, 327), border, 7.0f,
-            0, 1.0f);
+        draw->AddRectFilled(point(73, 282), point(279, 327),
+            snapshot->action_required ? amber_panel : top_bar,
+            scaled(7.0f));
+        draw->AddRect(point(73, 282), point(279, 327), border,
+            scaled(7.0f), 0, scaled(1.0f));
         if (snapshot->action_required) {
-            draw->AddRectFilled(ImVec2(73, 282), ImVec2(77, 327), amber,
-                7.0f);
+            draw->AddRectFilled(point(73, 282), point(77, 327), amber,
+                scaled(7.0f));
         }
         draw_text(draw, 10.0f, 84, 291,
             snapshot->action_required ? amber : secondary,
@@ -971,11 +1015,9 @@ load_preferences(void)
     int saved_presentation = GROUND_OPS_PRESENTATION_HIDDEN;
     int saved_mode = GROUND_OPS_WINDOW_FLOAT;
 
+    /* Ground Operations and its captions are part of the standard UI. */
     ui_enabled = B_TRUE;
-    (void)conf_get_b(bp_conf, "ground_ops_ui_enabled", &ui_enabled);
     captions_enabled = B_TRUE;
-    (void)conf_get_b(bp_conf, "ground_ops_captions_enabled",
-        &captions_enabled);
     if (conf_get_i(bp_conf, "ground_ops_presentation", &saved_presentation) &&
         ground_ops_presentation_valid(saved_presentation)) {
         presentation = static_cast<ground_ops_presentation_t>(
@@ -1240,6 +1282,9 @@ process_action(UiAction action)
     case UiAction::OpenPlanner:
         XPLMCommandOnce(start_pb);
         break;
+    case UiAction::ChangePlan:
+        XPLMCommandOnce(start_pb);
+        break;
     case UiAction::PausePush:
     case UiAction::ResumePush:
         XPLMCommandOnce(pause_pb);
@@ -1424,7 +1469,7 @@ ground_ops_ui_reset_context(void)
 extern "C" bool_t
 ground_ops_ui_is_enabled(void)
 {
-    return (ui_enabled);
+    return (B_TRUE);
 }
 
 extern "C" bool_t

--- a/src/ground_ops_ui.cpp
+++ b/src/ground_ops_ui.cpp
@@ -91,6 +91,7 @@ static bool_t initialized = B_FALSE;
 static bool_t ui_enabled = B_TRUE;
 static bool_t captions_enabled = B_TRUE;
 static bool_t planner_suspended = B_FALSE;
+static bool_t legacy_gate_hidden = B_FALSE;
 static bool_t have_float_rect = B_FALSE;
 static bool_t have_os_rect = B_FALSE;
 static ground_ops_rect_t float_rect = {};
@@ -575,6 +576,17 @@ private:
             text);
     }
 
+    static void draw_text_wrapped(ImDrawList *draw, float size, float x,
+        float y, float width, float height, ImU32 color, const char *text)
+    {
+        const ImVec2 start = point(x, y);
+
+        draw->PushClipRect(start, point(x + width, y + height), true);
+        draw->AddText(ImGui::GetFont(), scaled(size), start, color, text,
+            nullptr, scaled(width));
+        draw->PopClipRect();
+    }
+
     static ImVec2 measure_text(float size, const char *text)
     {
         return (ImGui::GetFont()->CalcTextSizeA(scaled(size),
@@ -912,7 +924,7 @@ private:
         draw_text(draw, 10.0f, 84, 291,
             snapshot->action_required ? amber : secondary,
             snapshot->action_required ? "PILOT ACTION" : "CURRENT TASK");
-        draw_text(draw, 11.0f, 84, 308, primary,
+        draw_text_wrapped(draw, 10.5f, 84, 304, 184, 23, primary,
             snapshot->current_task);
 
         if (end_confirmation_armed) {
@@ -1204,6 +1216,27 @@ hide_window(const char *reason)
 }
 
 static void
+apply_legacy_visibility(bool_t visible)
+{
+    bool_t hidden = visible ? B_FALSE : B_TRUE;
+
+    if (legacy_gate_hidden == hidden)
+        return;
+    legacy_gate_hidden = hidden;
+    if (!initialized || !ui_enabled || ground_window == nullptr ||
+        planner_suspended) {
+        return;
+    }
+
+    ground_window->SetVisible(visible);
+    if (manager_loop != nullptr) {
+        XPLMScheduleFlightLoop(manager_loop, visible ? -1.0f : 0.0f, 1);
+    }
+    logMsg(BP_INFO_LOG "Ground Ops UI %s by the legacy ground-speed gate",
+        visible ? "restored" : "temporarily hidden");
+}
+
+static void
 toggle_window_mode(void)
 {
     if (ground_window == nullptr)
@@ -1318,7 +1351,8 @@ manager_callback(float elapsed, float elapsed_flight, int counter,
     pending_action = UiAction::None;
     if (action != UiAction::None)
         process_action(action);
-    if (ground_window != nullptr && !planner_suspended) {
+    if (ground_window != nullptr && !planner_suspended &&
+        !legacy_gate_hidden) {
         local_data_poll_elapsed += elapsed;
         if (local_data_poll_elapsed >= LOCAL_DATA_POLL_SECONDS) {
             (void)refresh_local_data_context();
@@ -1440,6 +1474,7 @@ ground_ops_ui_fini(void)
     qnh_ref = nullptr;
     pending_action = UiAction::None;
     planner_suspended = B_FALSE;
+    legacy_gate_hidden = B_FALSE;
     geometry_poll_elapsed = 0;
     local_data_poll_elapsed = LOCAL_DATA_POLL_SECONDS;
     local_data_logged = false;
@@ -1475,7 +1510,14 @@ ground_ops_ui_is_enabled(void)
 extern "C" bool_t
 ground_ops_ui_is_visible(void)
 {
-    return (ground_window != nullptr && !planner_suspended);
+    return (ground_window != nullptr && !planner_suspended &&
+        !legacy_gate_hidden);
+}
+
+extern "C" void
+ground_ops_ui_set_legacy_visibility(bool_t visible)
+{
+    apply_legacy_visibility(visible);
 }
 
 extern "C" void
@@ -1522,8 +1564,8 @@ ground_ops_ui_resume_after_planner(void)
     planner_suspended = B_FALSE;
     (void)refresh_local_data_context();
     refresh_snapshot();
-    ground_window->SetVisible(B_TRUE);
-    if (manager_loop != nullptr)
+    ground_window->SetVisible(!legacy_gate_hidden);
+    if (manager_loop != nullptr && !legacy_gate_hidden)
         XPLMScheduleFlightLoop(manager_loop, -1.0f, 1);
     logMsg(BP_INFO_LOG "Ground Ops UI restored after planner close");
 }

--- a/src/ground_ops_ui.h
+++ b/src/ground_ops_ui.h
@@ -16,6 +16,7 @@ void ground_ops_ui_fini(void);
 void ground_ops_ui_reset_context(void);
 bool_t ground_ops_ui_is_enabled(void);
 bool_t ground_ops_ui_is_visible(void);
+void ground_ops_ui_set_legacy_visibility(bool_t visible);
 void ground_ops_ui_set_captions_enabled(bool_t enabled);
 void ground_ops_ui_toggle_visible(void);
 void ground_ops_ui_toggle_expanded(void);

--- a/src/ground_ops_window_state.c
+++ b/src/ground_ops_window_state.c
@@ -39,16 +39,28 @@ ground_ops_window_mode_valid(int mode)
         mode <= GROUND_OPS_WINDOW_POPOUT);
 }
 
+double
+ground_ops_ui_scale(void)
+{
+    return (GROUND_OPS_UI_SCALE);
+}
+
+int
+ground_ops_scaled_pixels(int logical_pixels)
+{
+    return ((int)(logical_pixels * ground_ops_ui_scale() + 0.5));
+}
+
 void
 ground_ops_presentation_size(ground_ops_presentation_t presentation,
     int *width, int *height)
 {
     if (presentation == GROUND_OPS_PRESENTATION_PANEL) {
-        *width = GROUND_OPS_PANEL_WIDTH;
-        *height = GROUND_OPS_PANEL_HEIGHT;
+        *width = ground_ops_scaled_pixels(GROUND_OPS_PANEL_WIDTH);
+        *height = ground_ops_scaled_pixels(GROUND_OPS_PANEL_HEIGHT);
     } else {
-        *width = GROUND_OPS_ORB_WIDTH;
-        *height = GROUND_OPS_ORB_HEIGHT;
+        *width = ground_ops_scaled_pixels(GROUND_OPS_ORB_WIDTH);
+        *height = ground_ops_scaled_pixels(GROUND_OPS_ORB_HEIGHT);
     }
 }
 

--- a/src/ground_ops_window_state.h
+++ b/src/ground_ops_window_state.h
@@ -27,6 +27,20 @@ extern "C" {
 #define GROUND_OPS_WINDOW_MARGIN 24
 #define GROUND_OPS_CLICK_DRAG_THRESHOLD 5
 
+#ifndef APL
+#define APL 0
+#endif
+
+#ifndef BP_EMULATE_MAC_UI_SCALE
+#define BP_EMULATE_MAC_UI_SCALE 0
+#endif
+
+#if APL || BP_EMULATE_MAC_UI_SCALE
+#define GROUND_OPS_UI_SCALE 1.35
+#else
+#define GROUND_OPS_UI_SCALE 1.0
+#endif
+
 typedef enum {
     GROUND_OPS_PRESENTATION_HIDDEN = 0,
     GROUND_OPS_PRESENTATION_ORB = 1,
@@ -52,6 +66,8 @@ typedef struct {
 
 bool ground_ops_presentation_valid(int presentation);
 bool ground_ops_window_mode_valid(int mode);
+double ground_ops_ui_scale(void);
+int ground_ops_scaled_pixels(int logical_pixels);
 void ground_ops_presentation_size(ground_ops_presentation_t presentation,
     int *width, int *height);
 void ground_ops_rect_resize_top_right(ground_ops_rect_t *rect, int width,

--- a/src/telemetry.c
+++ b/src/telemetry.c
@@ -61,6 +61,11 @@ bool_t
 bp_telemetry_open(bp_telemetry_t *telemetry, const char *filename,
     const bp_telemetry_metadata_t *metadata, double sample_hz)
 {
+    if (!BP_ENABLE_RUNTIME_TELEMETRY) {
+        if (telemetry != NULL)
+            memset(telemetry, 0, sizeof(*telemetry));
+        return (B_FALSE);
+    }
     if (telemetry == NULL || filename == NULL || metadata == NULL ||
         sample_hz <= 0)
         return (B_FALSE);

--- a/src/telemetry.h
+++ b/src/telemetry.h
@@ -25,6 +25,14 @@ extern "C" {
 
 #define BP_TELEMETRY_SCHEMA_VERSION 7
 
+/*
+ * Runtime CSV recording is diagnostic-only. Distribution builds leave it
+ * disabled so normal simulator use cannot accumulate unbounded output files.
+ */
+#ifndef BP_ENABLE_RUNTIME_TELEMETRY
+#define BP_ENABLE_RUNTIME_TELEMETRY 0
+#endif
+
 typedef struct {
     const char *plugin_version;
     const char *aircraft_icao;

--- a/src/tug.c
+++ b/src/tug.c
@@ -39,7 +39,6 @@
 #include "cfg.h"
 #include "driving.h"
 #include "tug.h"
-#include "vehicle_physics.h"
 #include "xplane.h"
 
 #define    TUG_STEER_RATE        40    /* deg/s */
@@ -52,6 +51,8 @@
 #define    TUG_MAX_REV_SPD        3    /* m/s */
 #define    TUG_MAX_ACCEL        1    /* m/s^2 */
 #define    TUG_MAX_DECEL        0.5    /* m/s^2 */
+
+#define    TUG_MIN_WHEELBASE    5    /* meters */
 
 #define    VOLUME_INSIDE_MODIFIER    0.5
 
@@ -831,8 +832,7 @@ tug_info_read(const char *tugdir, const char *tug_name, const char *icao,
     VALIDATE_TUG_REAL(ti->min_nlg_len, "min_nlg_len");
     VALIDATE_TUG_REAL(ti->lift_height, "lift_height");
     VALIDATE_TUG_REAL_NAN(ti->apch_dist, "apch_dist");
-    VALIDATE_TUG_REAL(ti->max_TE, "max_TE");
-    VALIDATE_TUG(ti->front_z <= ti->rear_z, "front_z/rear_z");
+    VALIDATE_TUG_REAL_NAN(ti->max_TE, "max_TE");
     VALIDATE_TUG_INT(ti->num_fwd_gears, "num_fwd_gears");
     VALIDATE_TUG_INT(ti->num_rev_gears, "num_rev_gears");
     VALIDATE_TUG_STR(ti->engine_snd, "engine_snd");
@@ -1208,7 +1208,7 @@ tug_alloc_common(tug_info_t *ti, double tirrad) {
     tug->info = ti;
     tug->tirrad = tirrad;
 
-    tug->veh.wheelbase = TUG_WHEELBASE(tug);
+    tug->veh.wheelbase = MAX(TUG_WHEELBASE(tug), TUG_MIN_WHEELBASE);
     tug->veh.fixed_z_off = tug->info->rear_z;
     tug->veh.max_steer = tug->info->max_steer;
     tug->veh.max_fwd_spd = tug->info->max_fwd_speed;
@@ -1448,10 +1448,19 @@ tug_run(tug_t *tug, double d_t, bool_t drive_slow) {
                    &tug->segs, &tug->last_mis_hdg, d_t, &steer, &speed, NULL);
     }
 
-    speed = vehicle_steering_speed_limit(speed, tug->veh.max_fwd_spd,
-        tug->veh.max_rev_spd, steer, tug->veh.max_steer);
-    accel = vehicle_speed_step(tug->pos.spd, speed, tug->veh.max_accel,
-        tug->veh.max_decel, d_t) - tug->pos.spd;
+    /* modulate our speed based on required steering angle */
+    if (speed > 0) {
+        speed = MIN(speed, tug->veh.max_fwd_spd *
+                           (1.1 - (steer / tug->veh.max_steer)));
+    } else {
+        speed = MAX(speed, -tug->veh.max_rev_spd *
+                           (1.1 - (steer / tug->veh.max_steer)));
+    }
+
+    if (speed >= tug->pos.spd)
+        accel = MIN(speed - tug->pos.spd, TUG_MAX_ACCEL * d_t);
+    else
+        accel = MAX(speed - tug->pos.spd, -TUG_MAX_ACCEL * d_t);
 
     if (steer >= tug->cur_steer)
         turn = MIN(steer - tug->cur_steer, TUG_STEER_RATE * d_t);
@@ -1462,7 +1471,7 @@ tug_run(tug_t *tug, double d_t, bool_t drive_slow) {
     if (!tug->steer_override)
         tug->cur_steer += turn;
 
-    radius = vehicle_turn_radius(tug->veh.wheelbase, tug->cur_steer);
+    radius = tan(DEG2RAD(90 - tug->cur_steer)) * tug->veh.wheelbase;
     if (radius > -1e3 && radius < 1e3) {
         double d_hdg = RAD2DEG((tug->pos.spd / radius) * d_t);
         vect2_t p2c = VECT2(radius, tug->info->rear_z);

--- a/src/tug.h
+++ b/src/tug.h
@@ -33,7 +33,7 @@
 extern "C" {
 #endif
 
-#define    TUG_WHEELBASE(tug)    ((tug)->info->front_z - (tug)->info->rear_z)
+#define    TUG_WHEELBASE(tug)    ((tug)->info->rear_z - (tug)->info->front_z)
 
 /* Defines how the tug lifts the aircraft up. */
 typedef enum {

--- a/tests/ground_ops_state_test.c
+++ b/tests/ground_ops_state_test.c
@@ -294,6 +294,19 @@ test_idle_workflow_requires_pilot_tug_call(void)
 }
 
 static void
+test_completed_task_has_bounded_two_line_copy(void)
+{
+    ground_ops_state_t state;
+    ground_ops_raw_state_t raw = idle_raw();
+
+    ground_ops_state_init(&state);
+    raw.prep_state = GROUND_OPS_PREP_COMPLETE;
+    assert(ground_ops_state_update(&state, &raw));
+    assert(strcmp(state.snapshot.current_task,
+        "Call tow assistance if the\naircraft must return") == 0);
+}
+
+static void
 test_provider_context_is_display_only(void)
 {
     ground_ops_state_t state;
@@ -420,6 +433,7 @@ main(void)
     test_pause_resume_actions_preserve_push_stage();
     test_end_from_pause_hold_uses_stationary_handoff();
     test_idle_workflow_requires_pilot_tug_call();
+    test_completed_task_has_bounded_two_line_copy();
     test_provider_context_is_display_only();
     test_called_connection_has_no_second_gate_before_capture();
     test_change_plan_is_only_offered_during_connected_hold();

--- a/tests/ground_ops_state_test.c
+++ b/tests/ground_ops_state_test.c
@@ -94,7 +94,7 @@ test_action_markers(void)
     assert(snapshot_for_step(PB_STEP_WAITING_FOR_PBRAKE).action_required);
     assert(snapshot_for_step(PB_STEP_CONNECTED).action_required);
     assert(snapshot_for_step(PB_STEP_STOPPED).action_required);
-    assert(snapshot_for_step(PB_STEP_WAITING4OK2DISCO).action_required);
+    assert(!snapshot_for_step(PB_STEP_WAITING4OK2DISCO).action_required);
     assert(!snapshot_for_step(PB_STEP_PUSHING).action_required);
     assert(!snapshot_for_step(PB_STEP_MOVING_AWAY).action_required);
 }
@@ -348,6 +348,31 @@ test_called_connection_has_no_second_gate_before_capture(void)
 }
 
 static void
+test_change_plan_is_only_offered_during_connected_hold(void)
+{
+    ground_ops_state_t state;
+    ground_ops_raw_state_t raw = idle_raw();
+
+    ground_ops_state_init(&state);
+    raw.operation_active = true;
+    raw.step = PB_STEP_CONNECTED;
+    raw.plan_complete = true;
+    raw.replan_available = true;
+    assert(ground_ops_state_update(&state, &raw));
+    assert(state.snapshot.primary_action == GROUND_OPS_ACTION_CHANGE_PLAN);
+    assert(strcmp(state.snapshot.primary_action_label, "Change plan") == 0);
+
+    raw.replan_available = false;
+    assert(ground_ops_state_update(&state, &raw));
+    assert(state.snapshot.primary_action == GROUND_OPS_ACTION_NONE);
+
+    raw.replan_available = true;
+    raw.step = PB_STEP_STARTING;
+    assert(ground_ops_state_update(&state, &raw));
+    assert(state.snapshot.primary_action == GROUND_OPS_ACTION_NONE);
+}
+
+static void
 test_emergency_tow_labels_and_actions(void)
 {
     ground_ops_state_t state;
@@ -397,6 +422,7 @@ main(void)
     test_idle_workflow_requires_pilot_tug_call();
     test_provider_context_is_display_only();
     test_called_connection_has_no_second_gate_before_capture();
+    test_change_plan_is_only_offered_during_connected_hold();
     test_emergency_tow_labels_and_actions();
     assert(sizeof(ground_ops_snapshot_t) < 1024);
     puts("ground_ops_state tests passed");

--- a/tests/ground_ops_window_state_test.c
+++ b/tests/ground_ops_window_state_test.c
@@ -15,10 +15,22 @@ test_contract_sizes(void)
 
     ground_ops_presentation_size(GROUND_OPS_PRESENTATION_ORB,
         &width, &height);
+#if APL || BP_EMULATE_MAC_UI_SCALE
+    assert(ground_ops_ui_scale() == 1.35);
+    assert(width == 78 && height == 329);
+#else
+    assert(ground_ops_ui_scale() == 1.0);
     assert(width == 58 && height == 244);
+#endif
     ground_ops_presentation_size(GROUND_OPS_PRESENTATION_PANEL,
         &width, &height);
+#if APL || BP_EMULATE_MAC_UI_SCALE
+    assert(width == 394 && height == 567);
+    assert(ground_ops_scaled_pixels(GROUND_OPS_CLICK_DRAG_THRESHOLD) == 7);
+#else
     assert(width == 292 && height == 420);
+    assert(ground_ops_scaled_pixels(GROUND_OPS_CLICK_DRAG_THRESHOLD) == 5);
+#endif
     assert(ground_ops_presentation_valid(GROUND_OPS_PRESENTATION_HIDDEN));
     assert(ground_ops_presentation_valid(GROUND_OPS_PRESENTATION_PANEL));
     assert(!ground_ops_presentation_valid(3));

--- a/tests/run_all_tests.sh
+++ b/tests/run_all_tests.sh
@@ -21,4 +21,15 @@ done
 printf 'Running wing_walker_asset_test.py\n'
 python3 "$test_dir/wing_walker_asset_test.py"
 
+printf 'Running runtime telemetry disabled test\n'
+repo_dir=$(CDPATH= cd -- "$test_dir/.." && pwd)
+telemetry_test_dir=$(mktemp -d)
+trap 'rm -rf "$telemetry_test_dir"' EXIT HUP INT TERM
+cc -std=c99 -Wall -Wextra -Werror \
+    -I"$repo_dir/src" -I"$repo_dir/../libacfutils/src" \
+    "$repo_dir/src/telemetry.c" "$test_dir/telemetry_disabled_test.c" \
+    -lm -o "$telemetry_test_dir/telemetry_disabled_test"
+"$telemetry_test_dir/telemetry_disabled_test" \
+    "$telemetry_test_dir/must_not_exist.csv"
+
 printf 'All BetterPushback regression tests passed.\n'

--- a/tests/run_ground_ops_window_state_tests.sh
+++ b/tests/run_ground_ops_window_state_tests.sh
@@ -4,6 +4,7 @@ set -eu
 test_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 repo_dir=$(CDPATH= cd -- "$test_dir/.." && pwd)
 test_bin="${TMPDIR:-/tmp}/betterpushback-ground-ops-window-state-test"
+mac_scale_test_bin="${TMPDIR:-/tmp}/betterpushback-ground-ops-window-state-mac-scale-test"
 
 cc -std=c99 -Wall -Wextra -Werror \
     -I"$repo_dir/src" \
@@ -12,4 +13,13 @@ cc -std=c99 -Wall -Wextra -Werror \
     -o "$test_bin"
 
 "$test_bin"
-rm -f "$test_bin"
+
+cc -std=c99 -Wall -Wextra -Werror \
+    -DBP_EMULATE_MAC_UI_SCALE=1 \
+    -I"$repo_dir/src" \
+    "$repo_dir/src/ground_ops_window_state.c" \
+    "$test_dir/ground_ops_window_state_test.c" \
+    -o "$mac_scale_test_bin"
+
+"$mac_scale_test_bin"
+rm -f "$test_bin" "$mac_scale_test_bin"

--- a/tests/run_vehicle_physics_tests.sh
+++ b/tests/run_vehicle_physics_tests.sh
@@ -14,6 +14,7 @@ cc -std=c99 -Wall -Wextra -Werror -I"$repo_dir/src" \
 "$test_bin"
 
 cc -std=c99 -Wall -Wextra -Werror -I"$repo_dir/src" \
+    -DBP_ENABLE_RUNTIME_TELEMETRY=1 \
     -I"$repo_dir/../libacfutils/src" \
     "$repo_dir/src/telemetry.c" "$test_dir/telemetry_test.c" \
     -lm -o "$telemetry_bin"

--- a/tests/telemetry_disabled_test.c
+++ b/tests/telemetry_disabled_test.c
@@ -1,0 +1,21 @@
+#include <assert.h>
+#include <stdio.h>
+
+#include "telemetry.h"
+
+int
+main(int argc, char **argv)
+{
+    bp_telemetry_t telemetry = {0};
+    bp_telemetry_metadata_t metadata = {0};
+    FILE *output;
+
+    assert(argc == 2);
+    assert(!BP_ENABLE_RUNTIME_TELEMETRY);
+    assert(!bp_telemetry_open(&telemetry, argv[1], &metadata, 10));
+    assert(telemetry.fp == NULL);
+
+    output = fopen(argv[1], "r");
+    assert(output == NULL);
+    return (0);
+}


### PR DESCRIPTION
The corrections include:

Restored the legacy BetterPushback route construction, steering, turn tracking, and planned stopping behavior. Only the configured tug towing-speed limits remain from our customized motion work.

Reintegrated Pause/Resume, End operation, and Emergency Tow around the legacy controller.

Removed the duplicate disconnect/reconnect cockpit windows from the default workflow and restored automatic disconnect.

Restored the upstream preferences, including ACF Plugin Exclusion, while removing obsolete controls related to the replaced operational UI.

Added the connected-state Change plan action.

Added macOS-specific Ground Operations scaling and corrected clipped tooltips and task text.

Restored and packaged the wing walker, including its OBJ, textures, and attribution.

Corrected the CURRENT TASK message so it remains inside the card.

Restored the legacy ground-speed behavior that hides and restores the Ground Operations interface.

Disabled automatic telemetry CSV recording in normal builds. It is now available only through an explicit diagnostic build option.